### PR TITLE
feat: seed data in strapi backend

### DIFF
--- a/publish-backend/.env.example
+++ b/publish-backend/.env.example
@@ -17,3 +17,6 @@ DATABASE_CLIENT=postgres
 
 # i18n
 STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE=en
+
+# Development
+SEED_DATA=false

--- a/publish-backend/package-lock.json
+++ b/publish-backend/package-lock.json
@@ -21,6 +21,9 @@
         "pg": "^8.11.2",
         "strapi-plugin-config-sync": "^1.1.2"
       },
+      "devDependencies": {
+        "@faker-js/faker": "^8.0.2"
+      },
       "engines": {
         "node": ">=14.19.1 <=18.x.x",
         "npm": ">=6.0.0"
@@ -1669,6 +1672,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
+      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/publish-backend/package.json
+++ b/publish-backend/package.json
@@ -33,5 +33,8 @@
     "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@faker-js/faker": "^8.0.2"
+  }
 }

--- a/publish-backend/src/index.js
+++ b/publish-backend/src/index.js
@@ -1,4 +1,6 @@
-'use strict';
+"use strict";
+
+const { generateSeedData } = require("./seed");
 
 module.exports = {
   /**
@@ -16,5 +18,14 @@ module.exports = {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/*{ strapi }*/) {},
+  async bootstrap({ strapi }) {
+    if (
+      process.env.NODE_ENV === "development" &&
+      process.env.SEED_DATA === "true"
+    ) {
+      console.log("Seeding database...");
+      await generateSeedData(strapi);
+      console.log("Seeding database complete!");
+    }
+  },
 };

--- a/publish-backend/src/seed/index.js
+++ b/publish-backend/src/seed/index.js
@@ -1,0 +1,134 @@
+const { faker } = require("@faker-js/faker");
+
+async function createSeedUsers(strapi) {
+  await strapi.entityService.create("plugin::users-permissions.user", {
+    data: {
+      username: "foo@bar.com",
+      email: "foo@bar.com",
+      password: "foobar",
+      confirmed: true,
+      role: {
+        connect: [3],
+      },
+    },
+  });
+  await strapi.entityService.create("plugin::users-permissions.user", {
+    data: {
+      username: "dev@user.com",
+      email: "dev@user.com",
+      password: "devuser",
+      confirmed: true,
+      role: {
+        connect: [3],
+      },
+    },
+  });
+}
+
+async function createSeedTags(strapi) {
+  await strapi.entityService.create("api::tag.tag", {
+    data: {
+      name: "HTML",
+    },
+  });
+  await strapi.entityService.create("api::tag.tag", {
+    data: {
+      name: "CSS",
+    },
+  });
+  await strapi.entityService.create("api::tag.tag", {
+    data: {
+      name: "JS",
+    },
+  });
+  await strapi.entityService.create("api::tag.tag", {
+    data: {
+      name: "Python",
+    },
+  });
+  await strapi.entityService.create("api::tag.tag", {
+    data: {
+      name: "Internal",
+      visibility: "internal",
+    },
+  });
+}
+
+async function createSeedPosts(strapi) {
+  await strapi.entityService.create("api::post.post", {
+    data: {
+      title: "Styled Post",
+      author: { connect: [1] },
+      tags: { connect: [1, 2, 3] },
+      body: '<p><strong>Bold</strong></p>\n\n<p><em>Italic</em></p>\n\n<p><s>Strike</s></p>\n\n<p><code>Code</code></p>\n\n<blockquote>"Quote"</blockquote>\n\n<h1>H1</h1>\n\n<h2>H2</h2>\n\n<h3>H3</h3>\n\n<ul>\n<li>Bullet</li>\n</ul>\n\n<ol>\n<li>Ordered</li>\n\n<li>Ordered</li>\n</ol>',
+      publishedAt: new Date(),
+    },
+  });
+  await strapi.entityService.create("api::post.post", {
+    data: {
+      title: "Lorem Post 1",
+      author: { connect: [2] },
+      tags: { connect: [1, 2, 4] },
+      body: faker.lorem.paragraphs(5),
+      publishedAt: new Date(),
+    },
+  });
+  await strapi.entityService.create("api::post.post", {
+    data: {
+      title: "Lorem Post 2",
+      author: { connect: [2] },
+      tags: { connect: [2, 3] },
+      body: faker.lorem.paragraphs(5),
+      publishedAt: new Date(),
+    },
+  });
+  await strapi.entityService.create("api::post.post", {
+    data: {
+      title: "Unpublished Lorem Post",
+      author: { connect: [2] },
+      tags: { connect: [2, 3] },
+      body: faker.lorem.paragraphs(5),
+    },
+  });
+  await strapi.entityService.create("api::post.post", {
+    data: {
+      title: "Internal post",
+      author: { connect: [2] },
+      tags: { connect: [5] },
+      body: "I'm an internal post and meant to be hidden",
+      publishedAt: new Date(),
+    },
+  });
+}
+
+async function generateSeedData(strapi) {
+  const dataExists = await strapi.entityService.findMany(
+    "plugin::users-permissions.user",
+    {
+      filters: {
+        $and: [
+          {
+            email: "foo@bar.com",
+          },
+          {
+            email: "dev@user.com",
+          },
+        ],
+      },
+    }
+  );
+
+  if (dataExists.length > 0) {
+    console.log("Seed data already exists, skipping...");
+    return;
+  }
+  console.log("Creating seed data...");
+
+  await createSeedUsers(strapi);
+  await createSeedTags(strapi);
+  await createSeedPosts(strapi);
+}
+
+module.exports = {
+  generateSeedData,
+};

--- a/publish-backend/src/seed/index.js
+++ b/publish-backend/src/seed/index.js
@@ -69,7 +69,7 @@ async function createSeedPosts(strapi) {
       title: "Lorem Post 1",
       author: { connect: [2] },
       tags: { connect: [1, 2, 4] },
-      body: faker.lorem.paragraphs(5),
+      body: faker.lorem.paragraphs(5, "<br/>\n"),
       publishedAt: new Date(),
     },
   });
@@ -78,7 +78,7 @@ async function createSeedPosts(strapi) {
       title: "Lorem Post 2",
       author: { connect: [2] },
       tags: { connect: [2, 3] },
-      body: faker.lorem.paragraphs(5),
+      body: faker.lorem.paragraphs(5, "<br/>\n"),
       publishedAt: new Date(),
     },
   });
@@ -87,7 +87,7 @@ async function createSeedPosts(strapi) {
       title: "Unpublished Lorem Post",
       author: { connect: [2] },
       tags: { connect: [2, 3] },
-      body: faker.lorem.paragraphs(5),
+      body: faker.lorem.paragraphs(5, "<br/>\n"),
     },
   });
   await strapi.entityService.create("api::post.post", {
@@ -106,7 +106,7 @@ async function generateSeedData(strapi) {
     "plugin::users-permissions.user",
     {
       filters: {
-        $and: [
+        $or: [
           {
             email: "foo@bar.com",
           },

--- a/publish-frontend/src/components/post-form.jsx
+++ b/publish-frontend/src/components/post-form.jsx
@@ -5,7 +5,7 @@ import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import slugify from 'slugify';
 import { Img } from '@chakra-ui/react';
 
-const PostForm = ({ tags }) => {
+const PostForm = ({ tags, initialValues }) => {
   // editing title
   const [title, setTitle] = useState('this is the title');
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -198,7 +198,7 @@ const PostForm = ({ tags }) => {
           </div>
         </div>
         <div className='editor' onClick={() => setIsFocused(true)}>
-          <Tiptap />
+          <Tiptap defaultValue={initialValues.attributes.body} />
         </div>
       </div>
     </div>

--- a/publish-frontend/src/components/tiptap.jsx
+++ b/publish-frontend/src/components/tiptap.jsx
@@ -113,7 +113,7 @@ function ToolBar({ editor }) {
   );
 }
 
-const Tiptap = ({}) => {
+const Tiptap = ({ defaultValue }) => {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -134,7 +134,9 @@ const Tiptap = ({}) => {
         inline: true
       })
     ],
-    content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla malesuada tortor nec purus viverra, ac laoreet nulla hendrerit. Proin ac vehicula lacus. Donec nulla diam, volutpat eu interdum non, pharetra non mi. In tempor nisi augue, vel volutpat lorem gravida id. Quisque sodales augue in aliquet lacinia. Phasellus interdum convallis orci, sollicitudin pharetra enim fringilla eu. Pellentesque suscipit laoreet ante ut luctus. Etiam sagittis massa id magna efficitur volutpat. Aenean id nulla ut tellus porttitor sagittis ac ut nunc. Fusce non velit vitae purus aliquam finibus convallis vitae justo. In pellentesque risus risus, vitae tincidunt augue iaculis eget. Morbi sed risus lobortis, euismod augue sit amet, lobortis sem.
+    content: defaultValue
+      ? defaultValue
+      : `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla malesuada tortor nec purus viverra, ac laoreet nulla hendrerit. Proin ac vehicula lacus. Donec nulla diam, volutpat eu interdum non, pharetra non mi. In tempor nisi augue, vel volutpat lorem gravida id. Quisque sodales augue in aliquet lacinia. Phasellus interdum convallis orci, sollicitudin pharetra enim fringilla eu. Pellentesque suscipit laoreet ante ut luctus. Etiam sagittis massa id magna efficitur volutpat. Aenean id nulla ut tellus porttitor sagittis ac ut nunc. Fusce non velit vitae purus aliquam finibus convallis vitae justo. In pellentesque risus risus, vitae tincidunt augue iaculis eget. Morbi sed risus lobortis, euismod augue sit amet, lobortis sem.
 
     Nunc vitae enim mauris. Aliquam volutpat dignissim diam, at sodales neque rutrum at. Etiam vestibulum ut orci imperdiet interdum. Duis ut venenatis purus. Aenean ac ultrices sapien. Curabitur sed diam nulla. Nunc ultrices, nisi vitae facilisis dapibus, augue nisi feugiat nisl, id sodales quam libero a sapien. Aliquam dolor justo, gravida rutrum leo in, hendrerit pulvinar elit. Quisque laoreet diam arcu, vel congue quam ullamcorper non. Quisque elit elit, condimentum nec tristique efficitur, lacinia id magna. Donec nec nibh eu nulla vestibulum efficitur. In tempus condimentum tempor. Aliquam eu ligula sed libero aliquam facilisis. Phasellus porttitor accumsan risus dictum placerat. Aenean suscipit velit at odio imperdiet, quis sodales dui molestie.`,
     autofocus: true,

--- a/publish-frontend/src/pages/posts/[postId].js
+++ b/publish-frontend/src/pages/posts/[postId].js
@@ -1,35 +1,39 @@
-import { useSession } from 'next-auth/react';
-import React, { useState, useEffect } from 'react';
 import PostForm from '@/components/post-form';
-import { useRouter } from 'next/router';
 import { getPost, updatePost } from '@/lib/posts';
+import { getTags } from '@/lib/tags';
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
 
-export default function EditPostPage({ tags }) {
+export async function getServerSideProps({ params }) {
+  const { postId } = params;
+  const { data: tags } = await getTags();
+  const { data: post } = await getPost(postId);
+  return {
+    props: { tags, post }
+  };
+}
+
+export default function EditPostPage({ tags, post }) {
   // Get auth data from the session
   const { data: session } = useSession();
   // declare state variables
-  const [post, setPost] = useState(null);
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState(post.attributes.body);
 
-  // Get the postId from the dynamic segment in the URL
-  const router = useRouter();
-  const { postId } = router.query;
+  // useEffect(() => {
+  //   // Fetch the post data from the server using the postId
+  //   const fetchPost = async () => {
+  //     try {
+  //       const data = await getPost(postId);
+  //       console.log('GET response: ', data);
+  //       setPost(data.data);
+  //       setContent(data.data.attributes.body);
+  //     } catch (error) {
+  //       console.error('Error fetching post:', error);
+  //     }
+  //   };
 
-  useEffect(() => {
-    // Fetch the post data from the server using the postId
-    const fetchPost = async () => {
-      try {
-        const data = await getPost(postId);
-        console.log('GET response: ', data);
-        setPost(data.data);
-        setContent(data.data.attributes.body);
-      } catch (error) {
-        console.error('Error fetching post:', error);
-      }
-    };
-
-    fetchPost();
-  }, [postId]);
+  //   fetchPost();
+  // }, [postId]);
 
   const handleContentChange = updatedContent => {
     setContent(updatedContent);
@@ -58,7 +62,7 @@ export default function EditPostPage({ tags }) {
 
     // Sending request
     try {
-      const result = await updatePost(postId, JSONdata, token);
+      const result = await updatePost(post.id, JSONdata, token);
       console.log('updatePost response: ', JSON.stringify(result));
       alert('Saved!');
     } catch (error) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

1. Delete the containers and volumes. Basically a fresh start.
2. Update your `.env` file to include `SEED_DATA` key
3. Leave it at `false` for the first run so that we can update the backend config
4. Start the containers
5. Import the backend config
6. Stop the containers
7. Update `SEED_DATA` to `true`
8. Start the containers again
9. Voila, the CMS has data now


The PR can be improved so that if the users are missing then it wipes and regenerates the data while keeping tracking of the IDs. 

I've not updated the docs as the dummy users created here will be the ones that can be used when #95 is in. So I felt that it was better to update the docs in one go once both PRs are in.