### PR TITLE
Revert "fix(deps): update strapi monorepo to v4.13.1"

### DIFF
--- a/publish-backend/package-lock.json
+++ b/publish-backend/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@ckeditor/strapi-plugin-ckeditor": "^0.0.7",
         "@strapi/plugin-documentation": "^4.11.5",
-        "@strapi/plugin-i18n": "4.13.1",
-        "@strapi/plugin-users-permissions": "4.13.1",
+        "@strapi/plugin-i18n": "4.12.7",
+        "@strapi/plugin-users-permissions": "4.12.7",
         "@strapi/provider-email-nodemailer": "^4.12.4",
-        "@strapi/strapi": "4.13.1",
+        "@strapi/strapi": "4.12.7",
         "axios": "^1.4.0",
         "better-sqlite3": "8.6.0",
         "eleventy-plugin-error-overlay": "^1.0.0",
@@ -3100,21 +3100,21 @@
       "peer": true
     },
     "node_modules/@strapi/admin": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.13.1.tgz",
-      "integrity": "sha512-hZ9ExxkldkyLzLuRGgAmMIPHkmZXRWrzU4AVOYuTF2Ov1Hwq4RLAMudFe5fdNHYQM/0Cyls5Lio2DI3d8SUfrg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.12.7.tgz",
+      "integrity": "sha512-eNd0s9gnP3eNMQxnkzaNJl3b2oz9IBWJ9SPAa6VrpE6k6ifKZqUFxqOk2WYChU7JfZSBaDIhmmGpU/xWO9N6KA==",
       "dependencies": {
         "@casl/ability": "^5.4.3",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-        "@strapi/data-transfer": "4.13.1",
+        "@strapi/data-transfer": "4.12.7",
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/permissions": "4.13.1",
-        "@strapi/provider-audit-logs-local": "4.13.1",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
-        "axios": "1.5.0",
+        "@strapi/permissions": "4.12.7",
+        "@strapi/provider-audit-logs-local": "4.12.7",
+        "@strapi/typescript-utils": "4.12.7",
+        "@strapi/utils": "4.12.7",
+        "axios": "1.4.0",
         "bcryptjs": "2.4.3",
         "browserslist": "^4.17.3",
         "browserslist-to-esbuild": "1.2.0",
@@ -3200,6 +3200,16 @@
         "@strapi/strapi": "^4.3.4"
       }
     },
+    "node_modules/@strapi/admin/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@strapi/admin/node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -3251,12 +3261,12 @@
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.13.1.tgz",
-      "integrity": "sha512-eEZEayF5WvvxjMD0UiBYvncRws5ocdOjaDjhPBKR1Grx9UEdzMrJi79paoylAO930dIkbSpsEmmIvImWpdXWNA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.12.7.tgz",
+      "integrity": "sha512-5sNBdo9RyNlWzqEjD6LT4Y7+zoUIVC9QuFcuLOZWOkBeLNKYxlQJOUWVzy7IAchAauoUsWsCtYWfQjf1+prSjg==",
       "dependencies": {
-        "@strapi/logger": "4.13.1",
-        "@strapi/strapi": "4.13.1",
+        "@strapi/logger": "4.12.7",
+        "@strapi/strapi": "4.12.7",
         "chalk": "4.1.2",
         "fs-extra": "10.0.0",
         "lodash": "4.17.21",
@@ -3290,11 +3300,11 @@
       }
     },
     "node_modules/@strapi/database": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.13.1.tgz",
-      "integrity": "sha512-9AeyONaHdaqL7/El1vyM3cw3s3brt8d4aiFUIhGLCWVZMJAVxRgobo/KtUCpdFuH0jHxxWbNz/hkjVBiYPm+PA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.12.7.tgz",
+      "integrity": "sha512-xnT2V8fkoqRU49Ex6DhZDhoIXbjMVDNI/LqTJor4bynMkYj6PmPR+BCXYE6ss6Zfvklx7VFEzgqt5+OB11hHUw==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "10.0.0",
@@ -3350,9 +3360,9 @@
       }
     },
     "node_modules/@strapi/generate-new": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.13.1.tgz",
-      "integrity": "sha512-YI7uP9HcELZAAHCslpXetoWfNW5XnCknreq5accKUm1kpQtE9gPfiUABgorx52RCLVyklJoH6/1wlBmJ0n0F4g==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.12.7.tgz",
+      "integrity": "sha512-uJhLC6kQWDnAQb47njCb4Nfldq38Q5v6BkoyvBxm7Bfqr3fifkdi/0SkNvrKEZkTjHlHqJaGdMEOSo/zPrIbOA==",
       "dependencies": {
         "@sentry/node": "6.19.7",
         "chalk": "^4.1.2",
@@ -3360,7 +3370,7 @@
         "fs-extra": "10.0.0",
         "inquirer": "8.2.5",
         "lodash": "4.17.21",
-        "node-fetch": "2.7.0",
+        "node-fetch": "2.6.9",
         "node-machine-id": "^1.1.10",
         "ora": "^5.4.1",
         "semver": "7.5.4",
@@ -3386,13 +3396,13 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.13.1.tgz",
-      "integrity": "sha512-YzFwJ+7pyFSMKEp9iDoDjDr769QP2PEhPGrRcnztKI7bCKCAs28xz0ff0hPKvPvDpbz83+1Yu3+yLEatcNZqRQ==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.12.7.tgz",
+      "integrity": "sha512-FyzdEim2e+FFXdj3dnvjowm8WRbIviGMNwtuLSlJ31PjXNYE8iwOKkeQzuJeDhHvUzJQD/lI8t4x8zhJ2W7W0Q==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/typescript-utils": "4.12.7",
+        "@strapi/utils": "4.12.7",
         "chalk": "4.1.2",
         "copyfiles": "2.4.1",
         "fs-extra": "10.0.0",
@@ -3406,11 +3416,11 @@
       }
     },
     "node_modules/@strapi/helper-plugin": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.13.1.tgz",
-      "integrity": "sha512-qUxUuVfeeXSmTEKykqEq36Y56iwg0WfZRK1xREuiLiLWguah7LpN1WEieZbItsMK8C/S6g4QNn9j78bx5vOvrg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.12.7.tgz",
+      "integrity": "sha512-Tg7wmJc5BIrY2nLPLOEVLk6v5FdcG1YEp7hsiRmTbEgZUsbwDdmmy5eROukpKR9pSF+TFOymYFG0em3gnPN96Q==",
       "dependencies": {
-        "axios": "1.5.0",
+        "axios": "1.4.0",
         "date-fns": "2.30.0",
         "formik": "2.4.0",
         "immer": "9.0.19",
@@ -3435,6 +3445,16 @@
         "styled-components": "^5.3.3"
       }
     },
+    "node_modules/@strapi/helper-plugin/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@strapi/icons": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-1.9.0.tgz",
@@ -3445,9 +3465,9 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.13.1.tgz",
-      "integrity": "sha512-JM6GX+XWSR1p6A7JU4D40MbhgXbKf49Rf2aJSIxlqZa/usGFa+DlEnzF9c+0DUw+XFj9oF+8CPebRbwRw4CmAQ==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.12.7.tgz",
+      "integrity": "sha512-G882eZoq9lbZjtJIG4kmkXW0EwHLiEuat2PVJ38IV733DMrwLJcK7f9DzkrE7eW7MVaSazTH0t1uPvhUNMyxUQ==",
       "dependencies": {
         "lodash": "4.17.21",
         "winston": "3.10.0"
@@ -3458,12 +3478,12 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.13.1.tgz",
-      "integrity": "sha512-yPL0/4gFrCkSbW1wB8EblWVGK1rU5+BFFoyEfLNoV91vq+ZE6LsVYaGP4mjtdAy6QaEfT5CD/9F3RsL2H7KKYg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.12.7.tgz",
+      "integrity": "sha512-mZx2QRRhocr/eifsVqmB0S2q8eq1JEgGy2rui1iLUY0+UjexMgSnGBjr9q2kXQJ50I2VRl9Qj9L1QWpRaq2cOQ==",
       "dependencies": {
         "@casl/ability": "5.4.4",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "lodash": "4.17.21",
         "sift": "16.0.1"
       },
@@ -3473,14 +3493,13 @@
       }
     },
     "node_modules/@strapi/plugin-content-manager": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.13.1.tgz",
-      "integrity": "sha512-A11YCpsgnfNp4qqVaSGLhpe3ayKwmTpxfU1+FU3xNy2FJiP/26l17hJ2Dmn1PC/w6AIS+6LC+rZtURzpF2Yz+g==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.12.7.tgz",
+      "integrity": "sha512-/jWgAT5kCy+3PNrZcORj81DUd6lRzQ0YWhwjmEx3ZWYBkdnYdW6pdbbT8JGS/hUqmdpk1lkMoE1sOtWRbGUCIw==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/utils": "4.13.1",
-        "lodash": "4.17.21",
-        "qs": "6.11.1"
+        "@strapi/utils": "4.12.7",
+        "lodash": "4.17.21"
       },
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
@@ -3488,16 +3507,16 @@
       }
     },
     "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.13.1.tgz",
-      "integrity": "sha512-m2L/WcZKs5OMV6sINdfo0JZQrB1H8zZMTjh8+nlN+eZ1bCdRhqDmUluyftIduW6i9i+sIKK2MRtvXQChabNMTQ==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.12.7.tgz",
+      "integrity": "sha512-KYmAW9yqIpLN0N0cCQ6gKz5/wddSbpaQ8F1v/kW415vKKjehVni5za5CJknKbwBF6EeakDfUE7IG9ikJLi1GOg==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "1.9.0",
-        "@strapi/generators": "4.13.1",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/generators": "4.12.7",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "fs-extra": "10.0.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3523,14 +3542,14 @@
       }
     },
     "node_modules/@strapi/plugin-documentation": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-documentation/-/plugin-documentation-4.13.1.tgz",
-      "integrity": "sha512-rZoDTIx368drgmdh19F1CYCicW/kkayxAG0XF98IjsN2QvSTscYnBTEiisqHmZIHGSjnFw4LKDYTyQ4i2F53Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-documentation/-/plugin-documentation-4.12.7.tgz",
+      "integrity": "sha512-tZuUszHKDF2QO803oIwz2mrF1Vpt5QRl5Wd7z1EzSo8VbYPfDFGno4W61dNfJcijF9XbFIOQxj7ZLSDrR+dFhw==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "bcryptjs": "2.4.3",
         "cheerio": "^1.0.0-rc.12",
         "formik": "2.4.0",
@@ -3559,18 +3578,17 @@
       }
     },
     "node_modules/@strapi/plugin-email": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.13.1.tgz",
-      "integrity": "sha512-VvX06ZjpyxRgoloRDfWMltyQGMbmffBd3j+f1BmLV5KL1cwyqOPdVaBrws9UJuUgPsCL8O8J9bAW+KxcVRmOew==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.12.7.tgz",
+      "integrity": "sha512-trDovwklpQo4XWLyYyidpk65ooDteEMF/WICUYwclm5FRZ5Yi4g2vTa+6QSNwJXCk+ZwQXGlpCGG3Lw3yzkADA==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-email-sendmail": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/provider-email-sendmail": "4.12.7",
+        "@strapi/utils": "4.12.7",
         "lodash": "4.17.21",
         "prop-types": "^15.8.1",
         "react-intl": "6.4.1",
-        "react-query": "3.39.3",
         "yup": "0.32.9"
       },
       "engines": {
@@ -3585,14 +3603,14 @@
       }
     },
     "node_modules/@strapi/plugin-i18n": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.13.1.tgz",
-      "integrity": "sha512-n0n/+BfgQ/c4xx6sYuh1cw12V8GTUVN+zQ/fBm2XW6nJOx6LGnHJPLa85QJOLFaIbC2oZR8tsFsyLl7e729hsw==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.12.7.tgz",
+      "integrity": "sha512-1n1Il7jmlPe8fghEU/3yJOV0GRJqoovpFOt8jPUEHQbZqbdpg36en+DQzS/fSLtXZQSgHJlhbElJqLCjiV8z7A==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "formik": "2.4.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3616,16 +3634,16 @@
       }
     },
     "node_modules/@strapi/plugin-upload": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.13.1.tgz",
-      "integrity": "sha512-OpaUSmO132ZVYl+LGrRQo/re4JejyAevvip/xuBHHM8lE2zDJCZG6VVTy4a9/eQF+c1uW1hEYSTtdlKs/64wpA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.12.7.tgz",
+      "integrity": "sha512-U93yzaEkEWseB2CHLQ7MOEDyUQ2MoBlZo963DSv9U11b/TirvnsJBwCfn6fZHZy09cQ6yr9F/CEqCGqEHsTqcw==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/provider-upload-local": "4.13.1",
-        "@strapi/utils": "4.13.1",
-        "axios": "1.5.0",
+        "@strapi/provider-upload-local": "4.12.7",
+        "@strapi/utils": "4.12.7",
+        "axios": "1.4.0",
         "byte-size": "7.0.1",
         "cropperjs": "1.5.12",
         "date-fns": "2.30.0",
@@ -3658,15 +3676,25 @@
         "styled-components": "5.3.3"
       }
     },
+    "node_modules/@strapi/plugin-upload/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.13.1.tgz",
-      "integrity": "sha512-RDk3HN1Nv/mxAi45kU8HFDJFlIg+GjvLh0MYr0DXV7xdKtK4q/C1IZs4NNYs+javIhA4kiozEFiTiNRoHfxmKg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.12.7.tgz",
+      "integrity": "sha512-dl7Ar1zVl0DWuL45FcYTPZDQDuS+S0FFbq+rjZBFBcmNHwAiGsw7jr+1PbGhb1Vc6N4EnDYXiLqDKawM8BiuBA==",
       "dependencies": {
         "@strapi/design-system": "1.9.0",
-        "@strapi/helper-plugin": "4.13.1",
+        "@strapi/helper-plugin": "4.12.7",
         "@strapi/icons": "1.9.0",
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "bcryptjs": "2.4.3",
         "formik": "2.4.0",
         "grant-koa": "5.4.8",
@@ -3737,9 +3765,9 @@
       }
     },
     "node_modules/@strapi/provider-audit-logs-local": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.13.1.tgz",
-      "integrity": "sha512-nuI5yHYdlAAAiSUGYtlmZUKqXowxjPJZnMGDKwBnnOO8P1dBXoUmdUqSD7mqSEAkdPeKxqpSTzzmrxtGxOvckQ==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.12.7.tgz",
+      "integrity": "sha512-V8gKlhwL5RK4cZabQSFqEk4h7pvAnobqIyY55vRqtl8XgyVyaAqLzJPhmFyDJXoms2IZvtUlZPLk3vN5i6XOLA==",
       "engines": {
         "node": ">=16.0.0 <=20.x.x",
         "npm": ">=6.0.0"
@@ -3749,9 +3777,9 @@
       }
     },
     "node_modules/@strapi/provider-email-nodemailer": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-4.13.1.tgz",
-      "integrity": "sha512-cWD0DbD2Op61lAqhxhxGVPuszxM59lByUuFSBx14gtgxV8gYgIKD15LU9p4CXx3N4D7JpTdF89CiTV39KLZY/g==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-4.12.7.tgz",
+      "integrity": "sha512-IE4BBvdIxO4FJYe5K2bqtTs0C8q1tkQlaScw4VFqJxvmXoFb7hkZio3UxIQscBqUD/1dkN0h/5s4n5X3aw05pg==",
       "dependencies": {
         "lodash": "4.17.21",
         "nodemailer": "6.9.1"
@@ -3762,11 +3790,11 @@
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.13.1.tgz",
-      "integrity": "sha512-mVNWkA6qdWUA7I0Pwz1Cw3Q540BhMJTlEz0BEy97iB9RPKDfN7KaisxJKdKisNxGSDHd9+m9+ejm1M9Wy116Gg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.12.7.tgz",
+      "integrity": "sha512-oJL+aDntUbofdp3aBn9umTdENM5NastC0+R4MA+J+HtcGTzIlxCk5VwaJPQ8vimFjIDpsuj3InQLSE+UFRUEKA==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -3775,11 +3803,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.13.1.tgz",
-      "integrity": "sha512-IqHoGnAuPDDt4Scix9heDBSmIqbUHZ0Z8rHhxjI/FMUHpKUO5OtMmukqeN9urtSm2wOndNRKxC5QnxdX7wSG/w==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.12.7.tgz",
+      "integrity": "sha512-3TzZNGPc/3p2UTCq4N6lRvbX494Km3HeR+cHLxt56DnX/tw9OXweJVWsYLuKq84BVp8I0U6b3FMNtGXI2wJryw==",
       "dependencies": {
-        "@strapi/utils": "4.13.1",
+        "@strapi/utils": "4.12.7",
         "fs-extra": "10.0.0"
       },
       "engines": {
@@ -3788,26 +3816,26 @@
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.13.1.tgz",
-      "integrity": "sha512-FI9RkcE2o3AMpwHI3Uk8WZ8v/5ByvilNL5eK2E0jbUzzXhnsW8QUlvUDOqrywS9Xp9J25xeSbxIPS44QVypIjA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.12.7.tgz",
+      "integrity": "sha512-9cDdDN4tjNXw3jW2qUh/gc0GL7Rgcw4jRfeUnSeVgeEEduvQR3Cit2DIgdHeQvtaN+80Iwj4wCAOLs951o4Bwg==",
       "hasInstallScript": true,
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/admin": "4.13.1",
-        "@strapi/data-transfer": "4.13.1",
-        "@strapi/database": "4.13.1",
-        "@strapi/generate-new": "4.13.1",
-        "@strapi/generators": "4.13.1",
-        "@strapi/logger": "4.13.1",
-        "@strapi/permissions": "4.13.1",
-        "@strapi/plugin-content-manager": "4.13.1",
-        "@strapi/plugin-content-type-builder": "4.13.1",
-        "@strapi/plugin-email": "4.13.1",
-        "@strapi/plugin-upload": "4.13.1",
-        "@strapi/typescript-utils": "4.13.1",
-        "@strapi/utils": "4.13.1",
+        "@strapi/admin": "4.12.7",
+        "@strapi/data-transfer": "4.12.7",
+        "@strapi/database": "4.12.7",
+        "@strapi/generate-new": "4.12.7",
+        "@strapi/generators": "4.12.7",
+        "@strapi/logger": "4.12.7",
+        "@strapi/permissions": "4.12.7",
+        "@strapi/plugin-content-manager": "4.12.7",
+        "@strapi/plugin-content-type-builder": "4.12.7",
+        "@strapi/plugin-email": "4.12.7",
+        "@strapi/plugin-upload": "4.12.7",
+        "@strapi/typescript-utils": "4.12.7",
+        "@strapi/utils": "4.12.7",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
@@ -3837,7 +3865,7 @@
         "koa-static": "5.0.0",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
-        "node-fetch": "2.7.0",
+        "node-fetch": "2.6.9",
         "node-machine-id": "1.1.12",
         "node-schedule": "2.1.0",
         "open": "8.4.0",
@@ -3912,9 +3940,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.13.1.tgz",
-      "integrity": "sha512-dFTeHPPbwlhkdQJVTB2H0pb8ZnB+uwQQhU81vy5GpPYYIuVmso6KnkmkfdB+tI09+Buic9nxVfQmFJBy0q8rLg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.12.7.tgz",
+      "integrity": "sha512-YFhB/0WfJpZxe0BJLbbtuPAtNwMMkozjooWzByn8Ah3UtSjef4otBsnuYy7ogruaxOH5cTCQ7E9w3gOyn/xpuw==",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
@@ -3961,9 +3989,9 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.13.1.tgz",
-      "integrity": "sha512-IW0ac0aeJbE6wptzW/7yZ4KPwRaqshHtNPCOrWAnG0L1Is/UkpwVUBUSmWq12m1utJF+nIenwgHH8jbKYolhFw==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.12.7.tgz",
+      "integrity": "sha512-M+huzEKfLVbwrWN9SwTGVZVNLAjMVtqmd21sCOKMp8sEtqSR62g9Ovr6XZHWHgl/m7nlqdpaQLJM9vLChMXMgA==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
@@ -4249,9 +4277,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
@@ -5972,9 +6000,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001523",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
+      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6554,9 +6582,9 @@
     },
     "node_modules/codemirror5": {
       "name": "codemirror",
-      "version": "5.65.15",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
-      "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
+      "version": "5.65.14",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.14.tgz",
+      "integrity": "sha512-VSNugIBDGt0OU9gDjeVr6fNkoFQznrWEUdAApMlXQNbfE8gGO19776D6MwSqF/V/w/sDwonsQ0z7KmmI9guScg=="
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
@@ -7859,9 +7887,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
+      "version": "1.4.503",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.503.tgz",
+      "integrity": "sha512-LF2IQit4B0VrUHFeQkWhZm97KuJSGF2WJqq1InpY+ECpFRkXd8yTIaTtJxsO0OKDmiBYwWqcrNaXOurn2T2wiA=="
     },
     "node_modules/eleventy-plugin-error-overlay": {
       "version": "1.0.0",
@@ -12817,9 +12845,10 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -14203,9 +14232,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.29",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
-      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "funding": [
         {
           "type": "opencollective",
@@ -17189,9 +17218,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
+      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -17498,7 +17527,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
@@ -18479,6 +18509,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -18487,7 +18518,8 @@
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "1.3.1",

--- a/publish-backend/package.json
+++ b/publish-backend/package.json
@@ -13,10 +13,10 @@
   "dependencies": {
     "@ckeditor/strapi-plugin-ckeditor": "^0.0.7",
     "@strapi/plugin-documentation": "^4.11.5",
-    "@strapi/plugin-i18n": "4.13.1",
-    "@strapi/plugin-users-permissions": "4.13.1",
+    "@strapi/plugin-i18n": "4.12.7",
+    "@strapi/plugin-users-permissions": "4.12.7",
     "@strapi/provider-email-nodemailer": "^4.12.4",
-    "@strapi/strapi": "4.13.1",
+    "@strapi/strapi": "4.12.7",
     "axios": "^1.4.0",
     "better-sqlite3": "8.6.0",
     "eleventy-plugin-error-overlay": "^1.0.0",


### PR DESCRIPTION
This reverts commit e35d093fddc913d28ada0c369da0c0443f8f4002.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Strapi seems to not build following the package update by Renovate. For some reason it dint update some of the other dependencies of strapi and the fix would be to delete `package-lock.json` and run `npm install`. But even then the updated strapi has an error when loading the `invited-user` model. There's an issue tracking the error - https://github.com/strapi/strapi/issues/17894