### PR TITLE
fix(backend): avoid hard coding role ID

### DIFF
--- a/publish-backend/src/seed/index.js
+++ b/publish-backend/src/seed/index.js
@@ -4,7 +4,23 @@ let userIds = []; // For now first user will be contributor and second will be e
 let tagIds = [];
 let internalTagId = null;
 
+const findRoleId = async (strapi, roleName) => {
+  try {
+    const role = await strapi.db
+      .query("plugin::users-permissions.role")
+      .findOne({
+        where: { name: roleName },
+      });
+    return role.id;
+  } catch (e) {
+    console.error(e);
+    throw new Error(`Failed to get Role ID for ${roleName}`);
+  }
+};
+
 async function createSeedUsers(strapi) {
+  const contributor = await findRoleId(strapi, "Contributor");
+  const editor = await findRoleId(strapi, "Editor");
   const userRes1 = await strapi.entityService.create(
     "plugin::users-permissions.user",
     {
@@ -16,7 +32,7 @@ async function createSeedUsers(strapi) {
         provider: "local",
         confirmed: true,
         role: {
-          connect: [3],
+          connect: [contributor],
         },
       },
     }
@@ -32,7 +48,7 @@ async function createSeedUsers(strapi) {
         provider: "local",
         confirmed: true,
         role: {
-          connect: [1],
+          connect: [editor],
         },
       },
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

~~Possibly related to #146~~ -> Checked with Niraj, it wasn't

<!-- Feel free to add any additional description of changes below this line -->

@Nirajn2311 While running tests, I found that `npm run cs import` doesn't always create role data in the same order. So the role ID changes. ~~This could be the reason why the role checking logic was flipped somewhere, which seems to have caused #146~~

It seems we can't specify the role ID when creating roles. So I fixed the seed code to look up the role ID when creating users.

I wasn't sure where to put helper functions like `findRoleId` in Strapi, so for now, I added it in the same file.