### PR TITLE
feat: auto set tag type when page loads

### DIFF
--- a/publish-frontend/src/pages/tags/index.js
+++ b/publish-frontend/src/pages/tags/index.js
@@ -20,6 +20,7 @@ import { useRouter } from 'next/router';
 import NavMenu from '@/components/nav-menu';
 import { getTags } from '@/lib/tags';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { useEffect } from 'react';
 
 export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -30,10 +31,17 @@ export async function getServerSideProps(context) {
   const internalTags = tags.data.filter(
     tag => tag.attributes.visibility === 'internal'
   );
+  let isInternal = false;
+
+  if (context.query.type) {
+    isInternal = true;
+  }
+
   return {
     props: {
       publicTags,
       internalTags,
+      isInternal,
       user: session.user
     }
   };
@@ -111,12 +119,25 @@ const TagFilterButton = ({ tagType, ...radioProps }) => {
   );
 };
 
-export default function TagsIndex({ publicTags, internalTags, user }) {
+export default function TagsIndex({
+  publicTags,
+  internalTags,
+  isInternal,
+  user
+}) {
   const router = useRouter();
 
   const { value, getRadioProps, getRootProps } = useRadioGroup({
-    defaultValue: 'public'
+    defaultValue: !isInternal ? 'public' : 'internal'
   });
+
+  useEffect(() => {
+    if (value === 'internal') {
+      router.replace('/tags?type=internal', undefined, { shallow: true });
+    } else {
+      router.replace('/tags', undefined, { shallow: true });
+    }
+  }, [value, router]);
 
   return (
     <Box minH='100vh' bgColor='gray.200'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This duplicates ghosts implementation of showing internal tags by default when query param is set in the link
