### PR TITLE
feat: make table's title focusable

### DIFF
--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -5,6 +5,7 @@ import {
   Flex,
   Grid,
   Heading,
+  Link as ChakraLink,
   Menu,
   MenuButton,
   MenuItemOption,
@@ -24,6 +25,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import intlFormatDistance from 'date-fns/intlFormatDistance';
 import { getServerSession } from 'next-auth/next';
 import { useRouter } from 'next/router';
+import NextLink from 'next/link';
 import { v4 as uuidv4 } from 'uuid';
 import NavMenu from '@/components/nav-menu';
 import { getPosts } from '@/lib/posts';
@@ -215,14 +217,32 @@ export default function IndexPage({ posts, users, tags, user }) {
                   <Tr
                     display='table-row'
                     key={post.id}
-                    cursor='pointer'
                     _hover={{
                       bgColor: 'rgb(243, 244, 246)'
                     }}
-                    onClick={() => router.push(`/posts/${post.id}`)}
                   >
-                    <Td>
-                      <Box fontWeight='600'>{title}</Box>
+                    <Td position='relative' display='flex' gap='.5em'>
+                      <ChakraLink
+                        background='transparent'
+                        as={NextLink}
+                        _hover={{
+                          background: 'transparent'
+                        }}
+                        _before={{
+                          content: '""',
+                          position: 'absolute',
+                          inset: '0',
+                          zIndex: '1',
+                          width: '100%',
+                          height: '100%',
+                          cursor: 'pointer',
+                          textDecoration: 'underline'
+                        }}
+                        href={`/posts/${post.id}`}
+                        fontWeight='600'
+                      >
+                        {title}
+                      </ChakraLink>
                       <Box as='span' fontSize='sm' color='gray.500'>
                         By{' '}
                         <Box as='span' fontWeight='500' color='gray.500'>

--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -223,7 +223,7 @@ export default function IndexPage({ posts, users, tags, user }) {
                     }}
                     position='relative'
                   >
-                    <Td  display='grid' gap='.25em'>
+                    <Td display='grid' gap='.25em'>
                       <ChakraLink
                         background='transparent'
                         as={NextLink}

--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -221,7 +221,7 @@ export default function IndexPage({ posts, users, tags, user }) {
                       bgColor: 'rgb(243, 244, 246)'
                     }}
                   >
-                    <Td position='relative' display='flex' gap='.5em'>
+                    <Td position='relative' display='grid' gap='.25em'>
                       <ChakraLink
                         background='transparent'
                         as={NextLink}
@@ -236,7 +236,6 @@ export default function IndexPage({ posts, users, tags, user }) {
                           width: '100%',
                           height: '100%',
                           cursor: 'pointer',
-                          textDecoration: 'underline'
                         }}
                         href={`/posts/${post.id}`}
                         fontWeight='600'

--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -120,6 +120,7 @@ export default function IndexPage({ posts, users, tags, user }) {
           position='sticky'
           top='0'
           bgColor='gray.200'
+          zIndex={2}
         >
           <Heading>Posts</Heading>
           <Spacer />

--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -223,10 +223,12 @@ export default function IndexPage({ posts, users, tags, user }) {
                     }}
                     position='relative'
                   >
-                    <Td display='grid' gap='.25em'>
+                    <Td>
                       <ChakraLink
                         background='transparent'
                         as={NextLink}
+                        display='block'
+                        marginBottom='.25em'
                         _hover={{
                           background: 'transparent'
                         }}

--- a/publish-frontend/src/pages/posts/index.js
+++ b/publish-frontend/src/pages/posts/index.js
@@ -221,8 +221,9 @@ export default function IndexPage({ posts, users, tags, user }) {
                     _hover={{
                       bgColor: 'rgb(243, 244, 246)'
                     }}
+                    position='relative'
                   >
-                    <Td position='relative' display='grid' gap='.25em'>
+                    <Td  display='grid' gap='.25em'>
                       <ChakraLink
                         background='transparent'
                         as={NextLink}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When you press tab next to the table it goes back to the navigation in your browser and skip the title, although it's an interactive content.

Used `Link` to make it interactive and added `before` pseudo-element, so we can have the same styles without the screen-readers reading the unnecessary context.
<!-- Feel free to add any additional description of changes below this line -->
