### PR TITLE
fix: align user name and email to left in nav menu

### DIFF
--- a/publish-frontend/src/components/nav-menu.jsx
+++ b/publish-frontend/src/components/nav-menu.jsx
@@ -129,7 +129,7 @@ const NavMenuContent = ({ user, onClose, ...rest }) => {
           >
             <Flex>
               <Avatar size='sm' mr='8px' my='auto' />
-              <Flex flexDirection='column'>
+              <Flex flexDirection='column' alignItems='flex-start'>
                 <Box fontWeight='600' lineHeight='1.1em' pb='3px'>
                   {user.name}
                 </Box>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently the name and email of the user would align to the centre in the nav menu.