### PR TITLE
feat(backend): prevent contributors updating other's post

### DIFF
--- a/apps/backend/src/api/helpers/services/helpers.js
+++ b/apps/backend/src/api/helpers/services/helpers.js
@@ -9,6 +9,10 @@ module.exports = () => ({
     if (process.env.DATA_MIGRATION === "true") {
       return true;
     }
-    return ctx.state.user.role.name === "Editor";
+    return ctx.state?.user?.role?.name === "Editor";
+  },
+  isAPIToken(ctx) {
+    // Checks if the current request is using an API Token instead of users-permissions login
+    return ctx.state?.auth?.strategy?.name === "api-token";
   },
 });

--- a/apps/backend/src/api/helpers/services/helpers.js
+++ b/apps/backend/src/api/helpers/services/helpers.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/**
+ * helpers service
+ */
+
+module.exports = () => ({
+  isEditor(ctx) {
+    if (process.env.DATA_MIGRATION === "true") {
+      return true;
+    }
+    return ctx.state.user.role.name === "Editor";
+  },
+});

--- a/apps/backend/src/api/post/controllers/post.js
+++ b/apps/backend/src/api/post/controllers/post.js
@@ -6,104 +6,110 @@
 
 const { createCoreController } = require("@strapi/strapi").factories;
 
-const isEditor = (ctx) => {
-  if (process.env.DATA_MIGRATION === "true") {
-    return true;
-  }
-  return ctx.state.user.role.name === "Editor";
-};
+module.exports = createCoreController("api::post.post", ({ strapi }) => {
+  const helpers = strapi.service("api::helpers.helpers");
 
-module.exports = createCoreController("api::post.post", ({ strapi }) => ({
-  async create(ctx) {
-    if (!isEditor(ctx)) {
-      // don't allow publishing or scheduling posts
-      delete ctx.request.body.data.publishedAt;
-      delete ctx.request.body.data.scheduled_at;
-      // don't allow code injection
-      delete ctx.request.body.data.codeinjection_head;
-      delete ctx.request.body.data.codeinjection_foot;
-    }
+  return {
+    async create(ctx) {
+      if (!helpers.isEditor(ctx)) {
+        // don't allow publishing or scheduling posts
+        delete ctx.request.body.data.publishedAt;
+        delete ctx.request.body.data.scheduled_at;
 
-    // call the default core action with modified data
-    return await super.create(ctx);
-  },
-  async update(ctx) {
-    if (!isEditor(ctx)) {
-      // don't allow publishing or scheduling posts
-      delete ctx.request.body.data.publishedAt;
-      delete ctx.request.body.data.scheduled_at;
-      // don't allow code injection
-      delete ctx.request.body.data.codeinjection_head;
-      delete ctx.request.body.data.codeinjection_foot;
-    }
+        // don't allow code injection
+        delete ctx.request.body.data.codeinjection_head;
+        delete ctx.request.body.data.codeinjection_foot;
 
-    // call the default core action with modified data
-    return await super.update(ctx);
-  },
-  async schedule(ctx) {
-    try {
-      const response = await strapi
-        .service("api::post.post")
-        .schedule(ctx.request.params.id, ctx.request.body);
+        // force set author to current user
+        delete ctx.request.body.data.author;
+        ctx.request.body.data.author = [ctx.state.user.id];
+      }
 
-      // this.transformResponse in controller transforms the response object
-      // into { data: { id: 1, attributes: {...} } } format
-      // to comply with other default endpoints
-      ctx.body = this.transformResponse(response);
-    } catch (err) {
-      ctx.body = err;
-    }
-  },
-  async publish(ctx) {
-    try {
-      const response = await strapi
-        .service("api::post.post")
-        .publish(ctx.request.params.id);
-      ctx.body = this.transformResponse(response);
-    } catch (err) {
-      ctx.body = err;
-    }
-  },
-  async unpublish(ctx) {
-    try {
-      const response = await strapi
-        .service("api::post.post")
-        .unpublish(ctx.request.params.id);
-      ctx.body = this.transformResponse(response);
-    } catch (err) {
-      ctx.body = err;
-    }
-  },
-  async checkAndPublish(ctx) {
-    try {
-      const draftPostToPublish = await strapi.entityService.findMany(
-        "api::post.post",
-        {
-          filters: {
-            publishedAt: {
-              $null: true,
-            },
-            scheduled_at: {
-              $lt: new Date(),
+      // call the default core action with modified data
+      return await super.create(ctx);
+    },
+    async update(ctx) {
+      if (!helpers.isEditor(ctx)) {
+        // don't allow publishing or scheduling posts
+        delete ctx.request.body.data.publishedAt;
+        delete ctx.request.body.data.scheduled_at;
+
+        // don't allow code injection
+        delete ctx.request.body.data.codeinjection_head;
+        delete ctx.request.body.data.codeinjection_foot;
+
+        // don't allow changing author
+        delete ctx.request.body.data.author;
+      }
+
+      // call the default core action with modified data
+      return await super.update(ctx);
+    },
+    async schedule(ctx) {
+      try {
+        const response = await strapi
+          .service("api::post.post")
+          .schedule(ctx.request.params.id, ctx.request.body);
+
+        // this.transformResponse in controller transforms the response object
+        // into { data: { id: 1, attributes: {...} } } format
+        // to comply with other default endpoints
+        ctx.body = this.transformResponse(response);
+      } catch (err) {
+        ctx.body = err;
+      }
+    },
+    async publish(ctx) {
+      try {
+        const response = await strapi
+          .service("api::post.post")
+          .publish(ctx.request.params.id);
+        ctx.body = this.transformResponse(response);
+      } catch (err) {
+        ctx.body = err;
+      }
+    },
+    async unpublish(ctx) {
+      try {
+        const response = await strapi
+          .service("api::post.post")
+          .unpublish(ctx.request.params.id);
+        ctx.body = this.transformResponse(response);
+      } catch (err) {
+        ctx.body = err;
+      }
+    },
+    async checkAndPublish(ctx) {
+      try {
+        const draftPostToPublish = await strapi.entityService.findMany(
+          "api::post.post",
+          {
+            filters: {
+              publishedAt: {
+                $null: true,
+              },
+              scheduled_at: {
+                $lt: new Date(),
+              },
             },
           },
-        },
-      );
+        );
 
-      await Promise.all(
-        draftPostToPublish.map((post) => {
-          return strapi.service("api::post.post").publish(post.id);
-        }),
-      );
+        await Promise.all(
+          draftPostToPublish.map((post) => {
+            return strapi.service("api::post.post").publish(post.id);
+          }),
+        );
 
-      const response = {
-        count: draftPostToPublish.length,
-        data: draftPostToPublish.map((post) => post.title),
-      };
+        const response = {
+          count: draftPostToPublish.length,
+          data: draftPostToPublish.map((post) => post.title),
+        };
 
-      ctx.body = this.transformResponse(response);
-    } catch (err) {
-      ctx.body = err;
-    }
-  },
-}));
+        ctx.body = this.transformResponse(response);
+      } catch (err) {
+        ctx.body = err;
+      }
+    },
+  };
+});

--- a/apps/backend/src/api/post/policies/is-own-post.js
+++ b/apps/backend/src/api/post/policies/is-own-post.js
@@ -7,30 +7,27 @@
 module.exports = async (policyContext, config, { strapi }) => {
   const helpers = strapi.service("api::helpers.helpers");
 
-  // Editors can update/delete any posts
+  // Editors can access any posts
   if (helpers.isEditor(policyContext)) {
     return true;
   }
 
-  // Contributors can only update/delete their own posts
-  if (["PUT", "DELETE"].includes(policyContext.state.route.method)) {
-    // Check the author of existing post
-    try {
-      const post = await strapi.entityService.findOne(
-        "api::post.post",
-        policyContext.params.id,
-        {
-          populate: ["author"],
-        },
-      );
-      if (post.author.id !== policyContext.state.user.id) {
-        return false;
-      }
-    } catch (err) {
-      strapi.log.error("Error in is-own-post policy.");
-      strapi.log.error(err);
+  // Contributors can only access their own posts
+  try {
+    const post = await strapi.entityService.findOne(
+      "api::post.post",
+      policyContext.params.id,
+      {
+        populate: ["author"],
+      },
+    );
+    if (post.author.id !== policyContext.state.user.id) {
       return false;
     }
+  } catch (err) {
+    strapi.log.error("Error in is-own-post policy.");
+    strapi.log.error(err);
+    return false;
   }
 
   return true;

--- a/apps/backend/src/api/post/policies/is-own-post.js
+++ b/apps/backend/src/api/post/policies/is-own-post.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/**
+ * `is-own-post` policy
+ */
+
+module.exports = async (policyContext, config, { strapi }) => {
+  const helpers = strapi.service("api::helpers.helpers");
+
+  // Editors can update/delete any posts
+  if (helpers.isEditor(policyContext)) {
+    return true;
+  }
+
+  // Contributors can only update/delete their own posts
+  if (["PUT", "DELETE"].includes(policyContext.state.route.method)) {
+    // Check the author of existing post
+    try {
+      const post = await strapi.entityService.findOne(
+        "api::post.post",
+        policyContext.params.id,
+        {
+          populate: ["author"],
+        },
+      );
+      if (post.author.id !== policyContext.state.user.id) {
+        return false;
+      }
+    } catch (err) {
+      strapi.log.error("Error in is-own-post policy.");
+      strapi.log.error(err);
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/apps/backend/src/api/post/routes/post.js
+++ b/apps/backend/src/api/post/routes/post.js
@@ -8,6 +8,9 @@ const { createCoreRouter } = require("@strapi/strapi").factories;
 
 module.exports = createCoreRouter("api::post.post", {
   config: {
+    findOne: {
+      policies: ["is-own-post"],
+    },
     update: {
       policies: ["is-own-post"],
     },

--- a/apps/backend/src/api/post/routes/post.js
+++ b/apps/backend/src/api/post/routes/post.js
@@ -6,4 +6,13 @@
 
 const { createCoreRouter } = require("@strapi/strapi").factories;
 
-module.exports = createCoreRouter("api::post.post");
+module.exports = createCoreRouter("api::post.post", {
+  config: {
+    update: {
+      policies: ["is-own-post"],
+    },
+    delete: {
+      policies: ["is-own-post"],
+    },
+  },
+});

--- a/apps/backend/tests/helpers/fixtures.js
+++ b/apps/backend/tests/helpers/fixtures.js
@@ -87,6 +87,18 @@ const setupFixtures = async () => {
           connect: [1, 2],
         },
       },
+      {
+        title: "Editor's draft post",
+        body: "<p>This is a post by editor user.</p>",
+        slug: "editors-draft-post",
+        publishedAt: null,
+        author: {
+          connect: [2],
+        },
+        tags: {
+          connect: [1, 2],
+        },
+      },
     ],
   };
 

--- a/apps/backend/tests/post/index.js
+++ b/apps/backend/tests/post/index.js
@@ -39,6 +39,24 @@ afterEach(async () => {
 });
 
 describe("post", () => {
+  describe("GET /posts", () => {
+    it("should return only the current user's posts for contributors", async () => {
+      const response = await request(strapi.server.httpServer)
+        .get(`/api/posts?populate=author`)
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send();
+
+      expect(response.status).toBe(200);
+      // check that all posts belong to the current user
+      const user = await getUser("contributor-user");
+      expect(
+        response.body.data.every(
+          (post) => post.attributes.author.data.id === user.id,
+        ),
+      ).toBe(true);
+    });
+  });
   describe("GET /posts/:id", () => {
     it("should prevent contributors viewing other user's post", async () => {
       const post = await getPost("editors-draft-post");

--- a/apps/backend/tests/post/index.js
+++ b/apps/backend/tests/post/index.js
@@ -39,6 +39,19 @@ afterEach(async () => {
 });
 
 describe("post", () => {
+  describe("GET /posts/:id", () => {
+    it("should prevent contributors viewing other user's post", async () => {
+      const post = await getPost("editors-draft-post");
+
+      const response = await request(strapi.server.httpServer)
+        .get(`/api/posts/${post.id}`)
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send();
+
+      expect(response.status).toBe(403);
+    });
+  });
   describe("POST /posts", () => {
     it("should create post including publishedAt and scheduled_at for editors", async () => {
       const response = await request(strapi.server.httpServer)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #128

<!-- Feel free to add any additional description of changes below this line -->

Contributor users shouldn't be able to create/update/delete other user's post.

- The API will return 403 forbidden error if contributor user tries to update/delete other user's post. `is-own-post` policy is doing this. Ref: [Strapi Policies](https://docs.strapi.io/dev-docs/backend-customization/policies)
- I couldn't find a straightforward way to validate if the `author` relation in a create/update request is their own user ID. So as a workaround, I made the controller to always set the current user's ID as the author.
- I moved `isEditor` function to a separate service called `helpers` so that it can be used in any endpoints. I'm not sure where to put generic functions like this, but it seems ok according to [this document.](https://docs.strapi.io/dev-docs/migration/v3-to-v4/code/configuration#custom-functions-folder)