### PR TITLE
fix: use shx cp for cross-platform compatibility

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,7 +12,7 @@
     "strapi": "strapi",
     "seed": "node ./scripts/seed.js",
     "cs": "config-sync",
-    "init": "cp --no-clobber sample.env .env && npm run cs import -- --yes",
+    "init": "shx cp --no-clobber sample.env .env && npm run cs import -- --yes",
     "test": "jest --forceExit",
     "test-verbose": "jest --forceExit --detectOpenHandles --verbose"
   },
@@ -46,6 +46,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "jest": "^29.6.4",
     "prettier": "^3.0.3",
+    "shx": "^0.3.4",
     "supertest": "^6.3.3"
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,7 +12,7 @@
     "strapi": "strapi",
     "seed": "node ./scripts/seed.js",
     "cs": "config-sync",
-    "init": "shx cp --no-clobber sample.env .env && npm run cs import -- --yes",
+    "init": "shx cp -n sample.env .env && npm run cs import -- --yes",
     "test": "jest --forceExit",
     "test-verbose": "jest --forceExit --detectOpenHandles --verbose"
   },

--- a/apps/cron/package.json
+++ b/apps/cron/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon src/index.ts # don't create a develop script unless you want turbo develop to start it",
-    "init": "shx cp --no-clobber sample.env .env",
+    "init": "shx cp -n sample.env .env",
     "prettier-check": "prettier --check .",
     "start": "NODE_ENV=production node prod/index.js",
     "type-check": "tsc --noEmit"

--- a/apps/cron/package.json
+++ b/apps/cron/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon src/index.ts # don't create a develop script unless you want turbo develop to start it",
-    "init": "cp --no-clobber sample.env .env",
+    "init": "shx cp --no-clobber sample.env .env",
     "prettier-check": "prettier --check .",
     "start": "NODE_ENV=production node prod/index.js",
     "type-check": "tsc --noEmit"
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^20.8.8",
     "nodemon": "^3.0.1",
+    "shx": "^0.3.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "develop": "npm run dev",
     "eslint": "next lint",
-    "init": "shx cp --no-clobber sample.env .env",
+    "init": "shx cp -n sample.env .env",
     "prettier-check": "prettier --check .",
     "start": "next start"
   },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "develop": "npm run dev",
     "eslint": "next lint",
-    "init": "cp --no-clobber sample.env .env",
+    "init": "shx cp --no-clobber sample.env .env",
     "prettier-check": "prettier --check .",
     "start": "next start"
   },
@@ -53,6 +53,7 @@
     "eslint-config-next": "^13.4.13",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-unused-imports": "^3.0.0",
-    "prettier": "^3.0.1"
+    "prettier": "^3.0.1",
+    "shx": "^0.3.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@strapi/plugin-users-permissions": "4.15.1",
         "@strapi/provider-email-nodemailer": "^4.12.4",
         "@strapi/strapi": "4.15.1",
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.6",
         "pg": "^8.11.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -39,6 +39,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "jest": "^29.6.4",
         "prettier": "^3.0.3",
+        "shx": "^0.3.4",
         "supertest": "^6.3.3"
       }
     },
@@ -105,6 +106,7 @@
       "devDependencies": {
         "@types/node": "^20.8.8",
         "nodemon": "^3.0.1",
+        "shx": "^0.3.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
@@ -153,7 +155,8 @@
         "eslint-config-next": "^13.4.13",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-unused-imports": "^3.0.0",
-        "prettier": "^3.0.1"
+        "prettier": "^3.0.1",
+        "shx": "^0.3.4"
       }
     },
     "apps/frontend/node_modules/eslint-config-prettier": {
@@ -22221,6 +22224,22 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`--no-clobber` is not supported by macos and replacing it with `-n` still generated errors when the file already existed. `shx cp -n` gets around both problems.

<!-- Feel free to add any additional description of changes below this line -->
