### PR TITLE
feat(backend): add slug_id to posts

### DIFF
--- a/apps/backend/config/sync/admin-role.strapi-super-admin.json
+++ b/apps/backend/config/sync/admin-role.strapi-super-admin.json
@@ -53,7 +53,8 @@
           "scheduled_at",
           "ghost_id",
           "codeinjection_head",
-          "codeinjection_foot"
+          "codeinjection_foot",
+          "slug_id"
         ],
         "locales": ["en"]
       },
@@ -93,7 +94,8 @@
           "scheduled_at",
           "ghost_id",
           "codeinjection_head",
-          "codeinjection_foot"
+          "codeinjection_foot",
+          "slug_id"
         ],
         "locales": ["en"]
       },
@@ -115,7 +117,8 @@
           "scheduled_at",
           "ghost_id",
           "codeinjection_head",
-          "codeinjection_foot"
+          "codeinjection_foot",
+          "slug_id"
         ],
         "locales": ["en"]
       },

--- a/apps/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##api##post.post.json
+++ b/apps/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##api##post.post.json
@@ -176,6 +176,20 @@
           "sortable": true
         }
       },
+      "slug_id": {
+        "edit": {
+          "label": "slug_id",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "slug_id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -293,6 +307,10 @@
         [
           {
             "name": "codeinjection_foot",
+            "size": 6
+          },
+          {
+            "name": "slug_id",
             "size": 6
           }
         ]

--- a/apps/backend/config/sync/user-role.authenticated.json
+++ b/apps/backend/config/sync/user-role.authenticated.json
@@ -28,6 +28,9 @@
       "action": "api::post.post.findOne"
     },
     {
+      "action": "api::post.post.findOneBySlugId"
+    },
+    {
       "action": "api::post.post.publish"
     },
     {

--- a/apps/backend/config/sync/user-role.contributor.json
+++ b/apps/backend/config/sync/user-role.contributor.json
@@ -19,6 +19,9 @@
       "action": "api::post.post.findOne"
     },
     {
+      "action": "api::post.post.findOneBySlugId"
+    },
+    {
       "action": "api::post.post.update"
     },
     {

--- a/apps/backend/src/api/post/content-types/post/lifecycles.js
+++ b/apps/backend/src/api/post/content-types/post/lifecycles.js
@@ -8,6 +8,8 @@ module.exports = {
         .service("api::post.post")
         .validatePublishedAt(new Date(data.publishedAt));
     }
+    // auto generate slug_id
+    data.slug_id = strapi.service("api::post.post").generateSlugId();
   },
   beforeUpdate(event) {
     const {

--- a/apps/backend/src/api/post/content-types/post/schema.json
+++ b/apps/backend/src/api/post/content-types/post/schema.json
@@ -106,6 +106,16 @@
         }
       },
       "type": "text"
+    },
+    "slug_id": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "maxLength": 8,
+      "unique": true
     }
   }
 }

--- a/apps/backend/src/api/post/controllers/post.js
+++ b/apps/backend/src/api/post/controllers/post.js
@@ -22,9 +22,23 @@ module.exports = createCoreController("api::post.post", ({ strapi }) => {
         }
         filters.author = [ctx.state.user.id];
         ctx.query.filters = filters;
-
         // call the default core action with modified ctx
         return await super.find(ctx);
+      }
+    },
+    async findOneBySlugId(ctx) {
+      try {
+        // find id from slug_id
+        const postId = await strapi
+          .service("api::post.post")
+          .findIdBySlugId(ctx.request.params.slug_id);
+
+        ctx.request.params.id = postId;
+
+        // pass it onto default findOne controller
+        return await super.findOne(ctx);
+      } catch (err) {
+        ctx.body = err;
       }
     },
     async create(ctx) {
@@ -58,6 +72,9 @@ module.exports = createCoreController("api::post.post", ({ strapi }) => {
         // don't allow changing author
         delete ctx.request.body.data.author;
       }
+
+      // prevent updating the slug ID
+      delete ctx.request.body.data.slug_id;
 
       // call the default core action with modified data
       return await super.update(ctx);

--- a/apps/backend/src/api/post/policies/is-own-post-slug-id.js
+++ b/apps/backend/src/api/post/policies/is-own-post-slug-id.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * `is-own-post-slug-id` policy
+ */
+
+module.exports = async (policyContext, config, { strapi }) => {
+  const helpers = strapi.service("api::helpers.helpers");
+
+  // Editors can access any posts
+  if (helpers.isEditor(policyContext)) {
+    return true;
+  }
+
+  // Contributors can only access their own posts
+  try {
+    // find author id from slug_id
+    const posts = await strapi.entityService.findMany("api::post.post", {
+      filters: { slug_id: policyContext.params.slug_id },
+      fields: ["id"],
+      populate: ["author"],
+    });
+
+    if (posts[0].author.id !== policyContext.state.user.id) {
+      return false;
+    }
+  } catch (err) {
+    strapi.log.error("Error in is-own-post-slug-id policy.");
+    strapi.log.error(err);
+    return false;
+  }
+
+  return true;
+};

--- a/apps/backend/src/api/post/routes/0-post.js
+++ b/apps/backend/src/api/post/routes/0-post.js
@@ -1,6 +1,15 @@
 module.exports = {
   routes: [
     {
+      method: "GET",
+      path: "/posts/slug_id/:slug_id",
+      handler: "post.findOneBySlugId",
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+    {
       method: "PATCH",
       path: "/posts/:id/schedule",
       handler: "post.schedule",

--- a/apps/backend/src/api/post/routes/0-post.js
+++ b/apps/backend/src/api/post/routes/0-post.js
@@ -1,3 +1,7 @@
+// Routes files are loaded in alphabetical order.
+// Using the filename starting with "0-" to load custom routes before core routes.
+
+// Custom routes
 module.exports = {
   routes: [
     {
@@ -5,7 +9,7 @@ module.exports = {
       path: "/posts/slug_id/:slug_id",
       handler: "post.findOneBySlugId",
       config: {
-        policies: [],
+        policies: ["is-own-post-slug-id"],
         middlewares: [],
       },
     },

--- a/apps/backend/src/api/post/routes/post.js
+++ b/apps/backend/src/api/post/routes/post.js
@@ -6,6 +6,7 @@
 
 const { createCoreRouter } = require("@strapi/strapi").factories;
 
+// Core routes
 module.exports = createCoreRouter("api::post.post", {
   config: {
     findOne: {

--- a/apps/backend/src/api/post/services/post.js
+++ b/apps/backend/src/api/post/services/post.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { ValidationError } = require("@strapi/utils").errors;
+const { customAlphabet } = require("nanoid");
 
 /**
  * post service
@@ -9,6 +10,17 @@ const { ValidationError } = require("@strapi/utils").errors;
 const { createCoreService } = require("@strapi/strapi").factories;
 
 module.exports = createCoreService("api::post.post", ({ strapi }) => ({
+  // finds id from slug_id
+  // returns null if not found
+  async findIdBySlugId(slug_id) {
+    // Have to use findMany instead of fineOne to search by slug_id
+    const postIds = await strapi.entityService.findMany("api::post.post", {
+      filters: { slug_id: slug_id },
+      fields: ["id"],
+    });
+    return postIds.length > 0 ? postIds[0].id : null;
+  },
+
   async create(reqBody = {}) {
     if (process.env.DATA_MIGRATION === "true") {
       reqBody.data.createdAt = reqBody.data.created_at;
@@ -51,5 +63,12 @@ module.exports = createCoreService("api::post.post", ({ strapi }) => ({
       throw new ValidationError("publishedAt must be a past date");
     }
     return true;
+  },
+
+  generateSlugId() {
+    // generate random 8 characters ID
+    const characterSet = "0123456789abcdefghijklmnopqrstuvwxyz";
+    const nanoid = customAlphabet(characterSet, 8);
+    return nanoid();
   },
 }));

--- a/apps/backend/tests/post/index.js
+++ b/apps/backend/tests/post/index.js
@@ -78,7 +78,11 @@ describe("post", () => {
       // find the post by slug_id through API
       const response = await request(strapi.server.httpServer)
         .get(`/api/posts/slug_id/${post.slug_id}`)
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send();
 
+      expect(response.status).toBe(200);
       const responsePost = response.body.data.attributes;
 
       expect(responsePost.slug_id).toEqual(post.slug_id);

--- a/apps/backend/tests/post/index.js
+++ b/apps/backend/tests/post/index.js
@@ -88,6 +88,19 @@ describe("post", () => {
       expect(responsePost.slug_id).toEqual(post.slug_id);
       expect(responsePost.slug).toEqual("test-slug");
     });
+    it("should prevent contributors viewing other user's post by slug_id", async () => {
+      // get slug_id from database
+      const post = await getPost("editors-draft-post");
+
+      // find the post by slug_id through API
+      const response = await request(strapi.server.httpServer)
+        .get(`/api/posts/slug_id/${post.slug_id}`)
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send();
+
+      expect(response.status).toBe(403);
+    });
   });
   describe("POST /posts", () => {
     it("should create post including publishedAt and scheduled_at for editors", async () => {

--- a/apps/backend/tests/post/index.js
+++ b/apps/backend/tests/post/index.js
@@ -70,6 +70,21 @@ describe("post", () => {
       expect(response.status).toBe(403);
     });
   });
+  describe("GET /posts/slug_id/:slug_id", () => {
+    it("should find post by slug_id", async () => {
+      // get slug_id from database
+      const post = await getPost("test-slug");
+
+      // find the post by slug_id through API
+      const response = await request(strapi.server.httpServer)
+        .get(`/api/posts/slug_id/${post.slug_id}`)
+
+      const responsePost = response.body.data.attributes;
+
+      expect(responsePost.slug_id).toEqual(post.slug_id);
+      expect(responsePost.slug).toEqual("test-slug");
+    });
+  });
   describe("POST /posts", () => {
     it("should create post including publishedAt and scheduled_at for editors", async () => {
       const response = await request(strapi.server.httpServer)
@@ -113,7 +128,7 @@ describe("post", () => {
     });
 
     it("should not set publishedAt to future date", async () => {
-      const postToCreateCopy = { ...postToCreate };
+      const postToCreateCopy = { data: { ...postToCreate.data } };
       const now = new Date();
       const oneHourFromNow = new Date(now.getTime() + 60 * 60 * 1000);
       postToCreateCopy.data.publishedAt = oneHourFromNow;
@@ -151,6 +166,20 @@ describe("post", () => {
         { populate: { author: true } },
       );
       expect(postCreated.author.id).toBe(currentUser.id);
+    });
+
+    it("should auto generate slug_id", async () => {
+      const response = await request(strapi.server.httpServer)
+        .post("/api/posts")
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send(JSON.stringify(postToCreate));
+
+      expect(response.status).toBe(200);
+      const responsePost = response.body.data.attributes;
+
+      // slug_id should consist of 8 characters from the lowercase letters and numbers
+      expect(responsePost.slug_id).toMatch(/^[0-9a-z]{8}$/);
     });
   });
 
@@ -305,6 +334,24 @@ describe("post", () => {
         post.id,
       );
       expect(postAfterRequest.title).toBe(newData.data.title);
+    });
+
+    it("should not change slug_id", async () => {
+      // get slug_id from database
+      const post = await getPost("test-slug");
+      const postCopy = { data: { ...post.data } };
+      postCopy.data.slug_id = "000000";
+
+      const response = await request(strapi.server.httpServer)
+        .put(`/api/posts/${post.id}`)
+        .set("Content-Type", "application/json")
+        .set("Authorization", `Bearer ${contributorJWT}`)
+        .send(JSON.stringify(postCopy));
+
+      expect(response.status).toBe(200);
+      const responsePost = response.body.data.attributes;
+
+      expect(responsePost.slug_id).toEqual(post.slug_id);
     });
   });
   describe("PATCH /posts/:id/schedule", () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #120 
Related to: #139

<!-- Feel free to add any additional description of changes below this line -->
Changes:
- Add a new column `slug_id` to posts
- Auto generate `slug_id` on creating a post
- Prevent changing `slug_id`manually through API
- Add an endpoint to find a post by `slug_id`

