### PR TITLE
chore: convert lint warnings to errors

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "develop": "npm run dev",
-    "eslint": "next lint",
+    "eslint": "next lint --max-warnings 0",
     "format": "prettier --write .",
     "init": "shx cp -n sample.env .env",
     "prettier-check": "prettier --check .",

--- a/apps/frontend/src/components/editor-drawer.jsx
+++ b/apps/frontend/src/components/editor-drawer.jsx
@@ -78,7 +78,7 @@ const EditorDrawer = ({
 
       setAuthorName(post.attributes.author.data.attributes.name);
     }
-  }, [post]);
+  }, [post, handlePostTagId]);
 
   const handleFileInputChange = (event) => {
     const file = event.target.files[0];

--- a/apps/frontend/src/components/post-form.jsx
+++ b/apps/frontend/src/components/post-form.jsx
@@ -69,10 +69,10 @@ const PostForm = ({ tags, user, authors, post }) => {
     setUnsavedChanges(true);
   };
 
-  const handlePostTagId = (value) => {
+  const handlePostTagId = useCallback((value) => {
     setPostTagId([...value]);
     setUnsavedChanges(true);
-  };
+  }, []);
 
   const handleAuthorChange = (author) => {
     setAuthor(author);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This means the warnings have to be fixed or deliberately ignored. Either way, they'll stop cluttering up the logs.

<!-- Feel free to add any additional description of changes below this line -->
