### PR TITLE
test: use user.id instead of magic numbers

### DIFF
--- a/apps/backend/tests/app.test.js
+++ b/apps/backend/tests/app.test.js
@@ -14,9 +14,9 @@ beforeAll(async () => {
   const fixtures = await setupFixtures();
 
   // Seed test database
-  await createTestUsers(fixtures.testUsers);
-  await createTestTags(fixtures.testTags);
-  await createTestPosts(fixtures.testPosts);
+  const users = await createTestUsers(fixtures.testUsers);
+  const tags = await createTestTags(fixtures.testTags);
+  await createTestPosts(fixtures.getTestPostsData, users, tags);
 });
 
 afterAll(cleanupStrapi);

--- a/apps/backend/tests/helpers/data.helper.js
+++ b/apps/backend/tests/helpers/data.helper.js
@@ -1,50 +1,42 @@
 // helper functions to seed the test database
 
 const createTestUsers = async (testUsers) => {
-  try {
-    for (const user of testUsers) {
-      await strapi.entityService.create("plugin::users-permissions.user", {
-        data: {
-          ...user,
-        },
-      });
-    }
-  } catch (e) {
-    console.error(e);
-    console.error(e.details.errors);
-    throw new Error("Failed to create mock users");
-  }
+  const editor = await strapi.entityService.create(
+    "plugin::users-permissions.user",
+    { data: testUsers.editor },
+  );
+  const contributor = await strapi.entityService.create(
+    "plugin::users-permissions.user",
+    { data: testUsers.contributor },
+  );
+
+  return {
+    editor,
+    contributor,
+  };
 };
 
 const createTestTags = async (testTags) => {
-  try {
-    for (const tag of testTags) {
-      await strapi.entityService.create("api::tag.tag", {
-        data: {
-          ...tag,
-        },
-      });
-    }
-  } catch (e) {
-    console.error(e);
-    console.error(e.details.errors);
-    throw new Error("Failed to create mock tags");
-  }
+  const html = await strapi.entityService.create("api::tag.tag", {
+    data: testTags.html,
+  });
+  const css = await strapi.entityService.create("api::tag.tag", {
+    data: testTags.css,
+  });
+
+  return {
+    html,
+    css,
+  };
 };
 
-const createTestPosts = async (testPosts) => {
-  try {
-    for (const post of testPosts) {
-      await strapi.entityService.create("api::post.post", {
-        data: {
-          ...post,
-        },
-      });
-    }
-  } catch (e) {
-    console.error(e);
-    console.error(e.details.errors);
-    throw new Error("Failed to create mock posts");
+const createTestPosts = async (generateTestPosts, users, tags) => {
+  const testPosts = await generateTestPosts(users, tags);
+
+  for (const data of testPosts) {
+    await strapi.entityService.create("api::post.post", {
+      data,
+    });
   }
 };
 

--- a/apps/backend/tests/helpers/fixtures.js
+++ b/apps/backend/tests/helpers/fixtures.js
@@ -5,8 +5,8 @@ const setupFixtures = async () => {
   const editor = await getRoleId("Editor");
 
   const fixtures = {
-    testUsers: [
-      {
+    testUsers: {
+      contributor: {
         name: "Contributor User",
         slug: "contributor-user",
         username: "contributor-user",
@@ -17,7 +17,7 @@ const setupFixtures = async () => {
           connect: [contributor],
         },
       },
-      {
+      editor: {
         name: "Editor User",
         slug: "editor-user",
         username: "editor-user",
@@ -28,78 +28,80 @@ const setupFixtures = async () => {
           connect: [editor],
         },
       },
-    ],
-    testTags: [
-      {
+    },
+    testTags: {
+      html: {
         name: "HTML",
         slug: "html",
       },
-      {
+      css: {
         name: "CSS",
         slug: "css",
       },
-    ],
-    testPosts: [
-      {
-        title: "Test Title",
-        body: "<p>test body</p>",
-        slug: "test-slug",
-        publishedAt: new Date("2023-08-30T00:00:00.000Z"),
-        code_injection_head:
-          '<script> const fCCOriginalPost = "https://www.freecodecamp.org/news/about/"; </script>',
-        author: {
-          connect: [1],
+    },
+    getTestPostsData({ editor, contributor }, { html, css }) {
+      return [
+        {
+          title: "Test Title",
+          body: "<p>test body</p>",
+          slug: "test-slug",
+          publishedAt: new Date("2023-08-30T00:00:00.000Z"),
+          code_injection_head:
+            '<script> const fCCOriginalPost = "https://www.freecodecamp.org/news/about/"; </script>',
+          author: {
+            connect: [contributor.id],
+          },
+          tags: {
+            connect: [html.id, css.id],
+          },
         },
-        tags: {
-          connect: [1, 2],
+        {
+          title: "test title 2",
+          body: "<p>test body 2</p>",
+          slug: "test-slug-2",
+          publishedAt: new Date("2023-08-30T04:09:32.928Z"),
+          author: { connect: [contributor.id] },
         },
-      },
-      {
-        title: "test title 2",
-        body: "<p>test body 2</p>",
-        slug: "test-slug-2",
-        publishedAt: new Date("2023-08-30T04:09:32.928Z"),
-        author: { connect: [1] },
-      },
-      {
-        title: "Draft Post",
-        body: "<p>draft post</p>",
-        slug: "draft-post",
-        publishedAt: null,
-        scheduled_at: null,
-        author: {
-          connect: [1],
+        {
+          title: "Draft Post",
+          body: "<p>draft post</p>",
+          slug: "draft-post",
+          publishedAt: null,
+          scheduled_at: null,
+          author: {
+            connect: [contributor.id],
+          },
+          tags: {
+            connect: [html.id, css.id],
+          },
         },
-        tags: {
-          connect: [1, 2],
+        {
+          title: "Published Post",
+          body: "<p>published post</p>",
+          slug: "published-post",
+          publishedAt: null,
+          scheduled_at: null,
+          author: {
+            connect: [contributor.id],
+          },
+          tags: {
+            connect: [html.id, css.id],
+          },
         },
-      },
-      {
-        title: "Published Post",
-        body: "<p>published post</p>",
-        slug: "published-post",
-        publishedAt: null,
-        scheduled_at: null,
-        author: {
-          connect: [1],
+        {
+          title: "Editor's draft post",
+          body: "<p>This is a post by editor user.</p>",
+          slug: "editors-draft-post",
+          publishedAt: null,
+          author: {
+            connect: [editor.id],
+          },
+          tags: {
+            connect: [html.id, css.id],
+          },
         },
-        tags: {
-          connect: [1, 2],
-        },
-      },
-      {
-        title: "Editor's draft post",
-        body: "<p>This is a post by editor user.</p>",
-        slug: "editors-draft-post",
-        publishedAt: null,
-        author: {
-          connect: [2],
-        },
-        tags: {
-          connect: [1, 2],
-        },
-      },
-    ],
+      ];
+    },
   };
 
   return fixtures;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The motivation is that I noticed that changing the order of the test users broke the tests. If we pass around user objects, the tests are both more robust and more declarative.

<!-- Feel free to add any additional description of changes below this line -->
