### PR TITLE
feat: add accept invitation endpoint

### DIFF
--- a/apps/backend/config/sync/admin-role.strapi-super-admin.json
+++ b/apps/backend/config/sync/admin-role.strapi-super-admin.json
@@ -21,7 +21,8 @@
           "codeinjection_head",
           "codeinjection_foot",
           "slug_id"
-        ]
+        ],
+        "locales": ["en"]
       },
       "conditions": []
     },
@@ -29,14 +30,18 @@
       "action": "plugin::content-manager.explorer.delete",
       "actionParameters": {},
       "subject": "api::post.post",
-      "properties": {},
+      "properties": {
+        "locales": ["en"]
+      },
       "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "actionParameters": {},
       "subject": "api::post.post",
-      "properties": {},
+      "properties": {
+        "locales": ["en"]
+      },
       "conditions": []
     },
     {
@@ -57,7 +62,8 @@
           "codeinjection_head",
           "codeinjection_foot",
           "slug_id"
-        ]
+        ],
+        "locales": ["en"]
       },
       "conditions": []
     },
@@ -79,7 +85,8 @@
           "codeinjection_head",
           "codeinjection_foot",
           "slug_id"
-        ]
+        ],
+        "locales": ["en"]
       },
       "conditions": []
     },
@@ -478,6 +485,34 @@
     },
     {
       "action": "plugin::email.settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.update",
       "actionParameters": {},
       "subject": null,
       "properties": {},

--- a/apps/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##i18n.locale.json
+++ b/apps/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##i18n.locale.json
@@ -1,0 +1,129 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::i18n.locale",
+  "value": {
+    "uid": "plugin::i18n.locale",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "code": {
+        "edit": {
+          "label": "code",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "code",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": ["id", "name", "code", "createdAt"],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "code",
+            "size": 6
+          }
+        ]
+      ]
+    }
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/apps/backend/config/sync/user-role.authenticated.json
+++ b/apps/backend/config/sync/user-role.authenticated.json
@@ -58,6 +58,9 @@
       "action": "plugin::upload.content-api.upload"
     },
     {
+      "action": "plugin::users-permissions.auth.acceptInvitation"
+    },
+    {
       "action": "plugin::users-permissions.auth.changePassword"
     },
     {

--- a/apps/backend/config/sync/user-role.authenticated.json
+++ b/apps/backend/config/sync/user-role.authenticated.json
@@ -61,6 +61,9 @@
       "action": "plugin::users-permissions.auth.changePassword"
     },
     {
+      "action": "plugin::users-permissions.auth.invitation"
+    },
+    {
       "action": "plugin::users-permissions.role.find"
     },
     {

--- a/apps/backend/config/sync/user-role.contributor.json
+++ b/apps/backend/config/sync/user-role.contributor.json
@@ -40,6 +40,9 @@
       "action": "plugin::upload.content-api.upload"
     },
     {
+      "action": "plugin::users-permissions.auth.acceptInvitation"
+    },
+    {
       "action": "plugin::users-permissions.role.find"
     },
     {

--- a/apps/backend/src/extensions/users-permissions/strapi-server.js
+++ b/apps/backend/src/extensions/users-permissions/strapi-server.js
@@ -50,6 +50,7 @@ module.exports = (plugin) => {
         data: {
           provider: "auth0",
           password: null,
+          status: "invited",
         },
       });
 

--- a/apps/backend/src/extensions/users-permissions/strapi-server.js
+++ b/apps/backend/src/extensions/users-permissions/strapi-server.js
@@ -25,6 +25,7 @@ module.exports = (plugin) => {
       });
   };
 
+  // TODO: find out if unshift is necessary or push will work.
   plugin.routes["content-api"].routes.unshift({
     method: "PUT",
     path: "/users/me",
@@ -35,5 +36,31 @@ module.exports = (plugin) => {
     },
   });
 
+  plugin.controllers.auth.invitation = async (ctx) => {
+    if (!ctx.state.user || !ctx.state.user.id) {
+      return (ctx.response.status = 401);
+    }
+
+    await strapi.query("plugin::users-permissions.user").update({
+      where: { id: ctx.request.params.id },
+      data: {
+        provider: "auth0",
+      },
+    });
+
+    ctx.response.status = 200;
+    ctx.response.body = {
+      status: "success",
+    };
+  };
+  plugin.routes["content-api"].routes.unshift({
+    method: "PUT",
+    path: "/auth/invitation/:id",
+    handler: "auth.invitation",
+    config: {
+      prefix: "",
+      policies: [],
+    },
+  });
   return plugin;
 };

--- a/apps/backend/src/extensions/users-permissions/strapi-server.js
+++ b/apps/backend/src/extensions/users-permissions/strapi-server.js
@@ -49,6 +49,7 @@ module.exports = (plugin) => {
         where: { id: ctx.request.params.id },
         data: {
           provider: "auth0",
+          password: null,
         },
       });
 

--- a/apps/backend/src/extensions/users-permissions/strapi-server.js
+++ b/apps/backend/src/extensions/users-permissions/strapi-server.js
@@ -1,3 +1,5 @@
+const DASHBOARD_URL = process.env.DASHBOARD_URL ?? "http://localhost:3000";
+
 module.exports = (plugin) => {
   plugin.controllers.user.updateMe = async (ctx) => {
     if (!ctx.state.user || !ctx.state.user.id) {
@@ -41,11 +43,20 @@ module.exports = (plugin) => {
       return (ctx.response.status = 401);
     }
 
-    await strapi.query("plugin::users-permissions.user").update({
-      where: { id: ctx.request.params.id },
-      data: {
-        provider: "auth0",
-      },
+    const { email } = await strapi
+      .query("plugin::users-permissions.user")
+      .update({
+        where: { id: ctx.request.params.id },
+        data: {
+          provider: "auth0",
+        },
+      });
+
+    await strapi.plugins.email.services.email.send({
+      to: email,
+      from: "support@freecodecamp.org",
+      subject: "Invitation Link",
+      text: `Here is your invitation link: ${DASHBOARD_URL}/api/auth/signin`,
     });
 
     ctx.response.status = 200;

--- a/apps/backend/src/extensions/users-permissions/strapi-server.js
+++ b/apps/backend/src/extensions/users-permissions/strapi-server.js
@@ -75,5 +75,33 @@ module.exports = (plugin) => {
       policies: [],
     },
   });
+
+  plugin.controllers.auth.acceptInvitation = async (ctx) => {
+    if (!ctx.state.user || !ctx.state.user.id) {
+      return (ctx.response.status = 401);
+    }
+
+    await strapi.query("plugin::users-permissions.user").update({
+      where: { id: ctx.state.user.id },
+      data: {
+        status: "active",
+      },
+    });
+
+    ctx.response.status = 200;
+    ctx.response.body = {
+      status: "success",
+    };
+  };
+
+  plugin.routes["content-api"].routes.unshift({
+    method: "PUT",
+    path: "/auth/accept-invitation/",
+    handler: "auth.acceptInvitation",
+    config: {
+      prefix: "",
+      policies: [],
+    },
+  });
   return plugin;
 };

--- a/apps/backend/tests/app.test.js
+++ b/apps/backend/tests/app.test.js
@@ -26,5 +26,6 @@ it("strapi is defined", () => {
 });
 
 require("./user");
+require("./auth");
 require("./custom-post");
 require("./post");

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -40,7 +40,7 @@ describe("auth", () => {
       jest.clearAllMocks();
     });
 
-    it("should set the user's provider to auth0 and delete the password", async () => {
+    it('should modify the user object into the "invited" state', async () => {
       // There are subtle differences between what services.user.add and
       // getUser return, so we use getUser for a fair comparison.
       const user = await getUser(mockUserData.username);
@@ -52,11 +52,12 @@ describe("auth", () => {
       expect(res.body).toEqual({ status: "success" });
       expect(res.status).toEqual(200);
       const updatedUser = await getUser(user.username);
-      expect(updatedUser).toEqual({
+      expect(updatedUser).toMatchObject({
         ...user,
         provider: "auth0",
         updatedAt: updatedUser.updatedAt,
         password: null,
+        status: "invited",
       });
     });
 

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -16,16 +16,17 @@ describe("auth", () => {
   describe("invitation", () => {
     let mockUser;
     let sendEmailSpy;
+    let editorToken;
 
     beforeEach(async () => {
       sendEmailSpy = jest
         .spyOn(strapi.plugins.email.services.email, "send")
         .mockImplementation(jest.fn());
-
       mockUser =
         await strapi.plugins["users-permissions"].services.user.add(
           mockUserData,
         );
+      editorToken = await getUserJWT("editor-user");
     });
 
     afterEach(() => {
@@ -37,8 +38,6 @@ describe("auth", () => {
       // There are subtle differences between what services.user.add and
       // getUser return, so we use getUser for a fair comparison.
       const user = await getUser(mockUserData.username);
-      // TODO: only allow admin
-      const editorToken = await getUserJWT("editor-user");
 
       const res = await request(strapi.server.httpServer)
         .put("/api/auth/invitation/" + user.id)
@@ -56,9 +55,6 @@ describe("auth", () => {
     });
 
     it("should email the invited user", async () => {
-      // TODO: only allow admin
-      const editorToken = await getUserJWT("editor-user");
-
       const res = await request(strapi.server.httpServer)
         .put("/api/auth/invitation/" + mockUser.id)
         .auth(editorToken, { type: "bearer" });
@@ -84,9 +80,6 @@ describe("auth", () => {
           password: mockUserData.password,
         });
       expect(loginResponse.status).toEqual(200);
-
-      // TODO: only allow admin
-      const editorToken = await getUserJWT("editor-user");
 
       await request(strapi.server.httpServer)
         .put("/api/auth/invitation/" + mockUser.id)

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -1,6 +1,6 @@
 "use strict";
 const request = require("supertest");
-const { getUser, getUserJWT } = require("../helpers/helpers");
+const { getUser, getUserJWT, deleteUser } = require("../helpers/helpers");
 
 // user mock data
 const mockUserData = {
@@ -14,6 +14,19 @@ const mockUserData = {
 
 describe("auth", () => {
   describe("invitation", () => {
+    let sendEmailSpy;
+
+    beforeEach(() => {
+      sendEmailSpy = jest
+        .spyOn(strapi.plugins.email.services.email, "send")
+        .mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+      deleteUser(mockUserData.username);
+      jest.clearAllMocks();
+    });
+
     it("should set the user's provider to auth0", async () => {
       await strapi.plugins["users-permissions"].services.user.add({
         ...mockUserData,
@@ -28,13 +41,36 @@ describe("auth", () => {
         .put("/api/auth/invitation/" + user.id)
         .auth(editorToken, { type: "bearer" });
 
-      expect(res.status).toEqual(200);
       expect(res.body).toEqual({ status: "success" });
+      expect(res.status).toEqual(200);
       const updatedUser = await getUser(user.username);
       expect(updatedUser).toEqual({
         ...user,
         provider: "auth0",
         updatedAt: updatedUser.updatedAt,
+      });
+    });
+
+    it("should email the invited user", async () => {
+      const { id } =
+        await strapi.plugins["users-permissions"].services.user.add(
+          mockUserData,
+        );
+      // TODO: only allow admin
+      const editorToken = await getUserJWT("editor-user");
+
+      const res = await request(strapi.server.httpServer)
+        .put("/api/auth/invitation/" + id)
+        .auth(editorToken, { type: "bearer" });
+
+      expect(res.body).toEqual({ status: "success" });
+      expect(res.status).toEqual(200);
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendEmailSpy).toHaveBeenCalledWith({
+        to: mockUserData.email,
+        from: "support@freecodecamp.org",
+        subject: "Invitation Link",
+        text: `Here is your invitation link: http://localhost:3000/api/auth/signin`,
       });
     });
   });

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -1,0 +1,41 @@
+"use strict";
+const request = require("supertest");
+const { getUser, getUserJWT } = require("../helpers/helpers");
+
+// user mock data
+const mockUserData = {
+  username: "tester",
+  email: "tester@strapi.com",
+  provider: "local",
+  password: "1234abc",
+  confirmed: true,
+  blocked: null,
+};
+
+describe("auth", () => {
+  describe("invitation", () => {
+    it("should set the user's provider to auth0", async () => {
+      await strapi.plugins["users-permissions"].services.user.add({
+        ...mockUserData,
+      });
+      // There are subtle differences between what services.user.add and
+      // getUser return, so we use getUser for a fair comparison.
+      const user = await getUser(mockUserData.username);
+      // TODO: only allow admin
+      const editorToken = await getUserJWT("editor-user");
+
+      const res = await request(strapi.server.httpServer)
+        .put("/api/auth/invitation/" + user.id)
+        .auth(editorToken, { type: "bearer" });
+
+      expect(res.status).toEqual(200);
+      expect(res.body).toEqual({ status: "success" });
+      const updatedUser = await getUser(user.username);
+      expect(updatedUser).toEqual({
+        ...user,
+        provider: "auth0",
+        updatedAt: updatedUser.updatedAt,
+      });
+    });
+  });
+});

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -6,6 +6,7 @@ const {
   deleteUser,
   getAllRoles,
   getUserByRole,
+  getRoleId,
 } = require("../helpers/helpers");
 
 // user mock data
@@ -16,6 +17,14 @@ const mockUserData = {
   password: "1234abc",
   confirmed: true,
   blocked: null,
+};
+
+const invitedUserData = {
+  username: "invited",
+  email: "invited@user.com",
+  provider: "auth0",
+  confirmed: false,
+  status: "invited",
 };
 
 describe("auth", () => {
@@ -125,6 +134,36 @@ describe("auth", () => {
           );
         }
       }
+    });
+  });
+
+  describe("accept-invitation", () => {
+    afterEach(() => {
+      deleteUser(invitedUserData.username);
+    });
+
+    // TODO: loop over all roles after fetching them with getAllRoles
+    const roles = ["Editor", "Contributor"];
+
+    roles.forEach((role) => {
+      it(`should set a ${role} user as active if they are not already`, async () => {
+        const roleId = await getRoleId(role);
+        await strapi.plugins["users-permissions"].services.user.add({
+          ...invitedUserData,
+          role: roleId,
+        });
+
+        const invitedUserToken = await getUserJWT(invitedUserData.username);
+
+        const res = await request(strapi.server.httpServer)
+          .put("/api/auth/accept-invitation/")
+          .auth(invitedUserToken, { type: "bearer" });
+
+        expect(res.status).toEqual(200);
+        expect(res.body).toEqual({ status: "success" });
+        const updatedUser = await getUser(invitedUserData.username);
+        expect(updatedUser.status).toEqual("active");
+      });
     });
   });
 });

--- a/apps/backend/tests/auth/index.js
+++ b/apps/backend/tests/auth/index.js
@@ -1,6 +1,12 @@
 "use strict";
 const request = require("supertest");
-const { getUser, getUserJWT, deleteUser } = require("../helpers/helpers");
+const {
+  getUser,
+  getUserJWT,
+  deleteUser,
+  getAllRoles,
+  getUserByRole,
+} = require("../helpers/helpers");
 
 // user mock data
 const mockUserData = {
@@ -98,24 +104,26 @@ describe("auth", () => {
       expect(deniedLoginResponse.status).toEqual(400);
     });
 
-    // TODO: enable once the administrator role exists.
-    it.skip("should reject requests from other roles", async () => {
-      // TODO: fetch all roles and test them directly (better future proofing)
-      const forbiddenUsers = ["contributor-user", "editor-user"];
+    // There is only one role for now, but this is designed to make sure we get
+    // warned before allowing new roles to invite users.
+    it("should reject requests from other role(s)", async () => {
+      const allRoles = await getAllRoles();
+      const forbiddenRoles = allRoles.filter(
+        ({ type }) => type !== "authenticated",
+      );
 
-      for (const username of forbiddenUsers) {
-        const token = await getUserJWT(username);
+      for (const role of forbiddenRoles) {
+        const user = await getUserByRole(role.id);
+        const token = await getUserJWT(user.username);
         const res = await request(strapi.server.httpServer)
           .put("/api/auth/invitation/" + mockUser.id)
           .auth(token, { type: "bearer" });
-        expect(res.status).toEqual(403);
+        if (res.status !== 403) {
+          throw new Error(
+            `Expected ${role.name} to be forbidden but it returned status: ${res.status}`,
+          );
+        }
       }
-
-      const res = await request(strapi.server.httpServer).put(
-        "/api/auth/invitation/" + mockUser.id,
-      );
-
-      expect(res.status).toEqual(403);
     });
   });
 });

--- a/apps/backend/tests/helpers/helpers.js
+++ b/apps/backend/tests/helpers/helpers.js
@@ -10,6 +10,11 @@ const getUser = async (username) => {
   }
 };
 
+const getUserByRole = async (roleId) =>
+  await strapi.db
+    .query("plugin::users-permissions.user")
+    .findOne({ where: { role: roleId }, populate: ["role"] });
+
 const deleteUser = async (username) => {
   try {
     return await strapi.db.query("plugin::users-permissions.user").delete({
@@ -20,6 +25,7 @@ const deleteUser = async (username) => {
     throw new Error(`Failed to delete User for ${username}`);
   }
 };
+
 const getPost = async (slug) => {
   try {
     return await strapi.db.query("api::post.post").findOne({
@@ -57,4 +63,17 @@ const getRoleId = async (roleName) => {
   }
 };
 
-module.exports = { deleteUser, getUser, getPost, getUserJWT, getRoleId };
+const getAllRoles = async () =>
+  await strapi.db.query("plugin::users-permissions.role").findMany({
+    where: { $not: { type: "public" } },
+  });
+
+module.exports = {
+  deleteUser,
+  getUser,
+  getPost,
+  getUserJWT,
+  getRoleId,
+  getUserByRole,
+  getAllRoles,
+};

--- a/apps/backend/tests/helpers/helpers.js
+++ b/apps/backend/tests/helpers/helpers.js
@@ -10,6 +10,16 @@ const getUser = async (username) => {
   }
 };
 
+const deleteUser = async (username) => {
+  try {
+    return await strapi.db.query("plugin::users-permissions.user").delete({
+      where: { username },
+    });
+  } catch (e) {
+    console.error(e);
+    throw new Error(`Failed to delete User for ${username}`);
+  }
+};
 const getPost = async (slug) => {
   try {
     return await strapi.db.query("api::post.post").findOne({
@@ -47,9 +57,4 @@ const getRoleId = async (roleName) => {
   }
 };
 
-module.exports = {
-  getUser,
-  getPost,
-  getUserJWT,
-  getRoleId,
-};
+module.exports = { deleteUser, getUser, getPost, getUserJWT, getRoleId };

--- a/apps/backend/tests/user/index.js
+++ b/apps/backend/tests/user/index.js
@@ -1,5 +1,9 @@
 const request = require("supertest");
-const { deleteUser } = require("../helpers/helpers");
+const {
+  deleteUser,
+  getUserByRole,
+  getAllRoles,
+} = require("../helpers/helpers");
 
 // user mock data
 const mockUserData = {
@@ -36,5 +40,19 @@ describe("user", () => {
       .then((data) => {
         expect(data.body.jwt).toBeDefined();
       });
+  });
+
+  // This just ensures that the test environment is set up with all types of
+  // user.
+  it("should have a user for each of the roles", async () => {
+    const roles = await getAllRoles();
+    for (const role of roles) {
+      const user = await getUserByRole(role.id);
+      expect(user).toMatchObject({
+        role: {
+          name: role.name,
+        },
+      });
+    }
   });
 });

--- a/apps/backend/tests/user/index.js
+++ b/apps/backend/tests/user/index.js
@@ -1,4 +1,5 @@
 const request = require("supertest");
+const { deleteUser } = require("../helpers/helpers");
 
 // user mock data
 const mockUserData = {
@@ -13,6 +14,9 @@ const mockUserData = {
 describe("user", () => {
   // Example test taken from https://docs.strapi.io/dev-docs/testing
   // This test should pass if the test environment is set up properly
+  afterAll(async () => {
+    await deleteUser(mockUserData.username);
+  });
   it("should login user and return jwt token", async () => {
     /** Creates a new user and save it to the database */
     await strapi.plugins["users-permissions"].services.user.add({


### PR DESCRIPTION
This is another followup PR (to https://github.com/freeCodeCamp/publish/pull/343)  and only the last two commits are new.

Thanks to @Nirajn2311 for the suggestion to allow any authenticated user to tell the api that they've "accepted the invitation". I had considered extending the `api/auth/auth0/callback` endpoint, but this approach is nicer. It's less likely to break when the `users-permissions` plugin is updated and it keeps the logic separated.

Once this is in, we'll need to:

- [ ] Disable registrations in general
- [ ] Only allow Editors to create users (including setting the status to "new", for example)
- [ ] Re-implement the users page, making use of the `status` to differentiate between active and invited users

We can probably filter out `new` users, since they'll only have that status after they've been created, but before they've been invited. i.e. a few milliseconds.

@sidemt I hijacked `user.status` for the invitation flow, but if this interferes with your plans for that, just let me know and I'll come up with another approach.

