### PR TITLE
feat: convert auth0 domain to issuer url

### DIFF
--- a/apps/frontend/src/pages/api/auth/[...nextauth].js
+++ b/apps/frontend/src/pages/api/auth/[...nextauth].js
@@ -39,7 +39,7 @@ export const authOptions = {
     Auth0Provider({
       clientId: process.env.AUTH0_CLIENT_ID,
       clientSecret: process.env.AUTH0_CLIENT_SECRET,
-      issuer: process.env.AUTH0_DOMAIN,
+      issuer: `https://${process.env.AUTH0_DOMAIN}`,
     }),
   ],
 


### PR DESCRIPTION
Auth0Provider expects the full URL, but Auth0's dashboard provides the
domain. This converts between the two because it's easy to forget.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'll need to update the deployment pipeline, so please @ me after reviewing.

<!-- Feel free to add any additional description of changes below this line -->
