### PR TITLE
fix: improve UI and design based on feedback from authors

### DIFF
--- a/apps/frontend/src/components/post-form.jsx
+++ b/apps/frontend/src/components/post-form.jsx
@@ -247,109 +247,128 @@ const PostForm = ({ tags, user, authors, post }) => {
 
   return (
     <>
-      <Flex>
-        <Flex flexDirection="column" mr="1rem" maxWidth="100%" flex="4">
-          <Flex m="1rem 0 0 5rem">
-            <Box>
-              <Button
-                variant="link"
-                as={NextLink}
-                href="/posts/"
-                leftIcon={<FontAwesomeIcon size="lg" icon={faChevronLeft} />}
-              >
-                <Text fontSize="2xl">Posts</Text>
-              </Button>
-            </Box>
-            <Box ml="auto" display={"flex"}>
-              {isEditor(user) && (
-                <ScheduleMenu handleSubmit={handleSubmit} post={post} />
-              )}
-              <EditorDrawer
-                tags={tags}
-                authors={authors}
-                user={user}
-                post={post}
-                postTagId={postTagId}
-                title={title}
-                postUrl={postUrl}
-                featureImage={featureImage}
-                handleTitleChange={handleTitleChange}
-                handlePostUrlChange={handlePostUrlChange}
-                handleAuthorChange={handleAuthorChange}
-                handleUnsavedChanges={handleUnsavedChanges}
-                handleFeatureImageChange={handleFeatureImageChange}
-                handlePostTagId={handlePostTagId}
-                handleSubmit={handleSubmit}
-              />
-            </Box>
-          </Flex>
-          <Flex m="1rem 0 0 5rem" flexDir={{ base: "column", lg: "row" }}>
-            {!isEditingTitle ? (
-              <>
-                <Stack direction="row" onClick={() => setIsEditingTitle(true)}>
-                  <Text fontSize="2xl" data-testid="post-title">
-                    {title}
-                  </Text>
-                  <Text fontSize="2xl">
-                    <FontAwesomeIcon icon={faEdit} />
-                  </Text>
-                </Stack>
-              </>
-            ) : (
-              <Formik
-                initialValues={{ title: title }}
-                onSubmit={(values, actions) => {
-                  setTitle(values.title);
-                  setIsEditingTitle(false);
-                  actions.setSubmitting(false);
-                  setUnsavedChanges(true);
-                }}
-              >
-                {(props) => (
-                  <Form style={{ width: "100%" }}>
-                    <Stack direction={{ base: "column", lg: "row" }}>
-                      <Field name="title">
-                        {({ field, form }) => (
-                          <FormControl
-                            w="30%"
-                            isInvalid={form.errors.title && form.touched.title}
-                          >
-                            <Input
-                              {...field}
-                              placeholder="Title"
-                              data-testid="post-title-field"
-                              required
-                            />
-                            <FormErrorMessage>
-                              {form.errors.title}
-                            </FormErrorMessage>
-                          </FormControl>
-                        )}
-                      </Field>
-                      <Button
-                        colorScheme="blue"
-                        isLoading={props.isSubmitting}
-                        type="submit"
-                        w="15%"
-                        margin={{ base: "0 0 1rem 0" }}
-                      >
-                        Done
-                      </Button>
-                    </Stack>
-                  </Form>
-                )}
-              </Formik>
+      <Flex
+        flexDirection="column"
+        m="0 1rem"
+        h="100vh"
+        maxWidth="100%"
+        flex="4"
+      >
+        <Flex m="1rem auto 0 auto" w="100%">
+          <Box>
+            <Button
+              variant="link"
+              as={NextLink}
+              href="/posts/"
+              leftIcon={<FontAwesomeIcon size="lg" icon={faChevronLeft} />}
+            >
+              <Text fontSize="2xl">Posts</Text>
+            </Button>
+          </Box>
+          <Box ml="auto" display={"flex"}>
+            {isEditor(user) && (
+              <ScheduleMenu handleSubmit={handleSubmit} post={post} />
             )}
-          </Flex>
-          <Box p="0 0 0 5rem">
-            <Tiptap
-              handleContentChange={handleContentChange}
-              content={content}
+            <EditorDrawer
+              tags={tags}
+              authors={authors}
               user={user}
-              postId={postId}
+              post={post}
+              postTagId={postTagId}
+              title={title}
+              postUrl={postUrl}
+              featureImage={featureImage}
+              handleTitleChange={handleTitleChange}
+              handlePostUrlChange={handlePostUrlChange}
+              handleAuthorChange={handleAuthorChange}
+              handleUnsavedChanges={handleUnsavedChanges}
+              handleFeatureImageChange={handleFeatureImageChange}
+              handlePostTagId={handlePostTagId}
+              handleSubmit={handleSubmit}
             />
           </Box>
         </Flex>
+        <Flex
+          m="1rem auto 0 auto"
+          w="100%"
+          maxW="1060px"
+          flexDir={{ base: "column", lg: "row" }}
+        >
+          {!isEditingTitle ? (
+            <>
+              <Stack
+                w="100%"
+                maxW="1060px"
+                direction="row"
+                onClick={() => setIsEditingTitle(true)}
+              >
+                <Text
+                  fontSize="2xl"
+                  overflowWrap="break-word"
+                  wordBreak="break-word"
+                  data-testid="post-title"
+                >
+                  {title}
+                </Text>
+                <Text fontSize="2xl">
+                  <FontAwesomeIcon icon={faEdit} />
+                </Text>
+              </Stack>
+            </>
+          ) : (
+            <Formik
+              initialValues={{ title: title }}
+              onSubmit={(values, actions) => {
+                setTitle(values.title);
+                setIsEditingTitle(false);
+                actions.setSubmitting(false);
+                setUnsavedChanges(true);
+              }}
+            >
+              {(props) => (
+                <Form style={{ width: "100%" }}>
+                  <Stack direction={{ base: "column", lg: "row" }}>
+                    <Field name="title">
+                      {({ field, form }) => (
+                        <FormControl
+                          w="100%"
+                          isInvalid={form.errors.title && form.touched.title}
+                        >
+                          <Input
+                            {...field}
+                            placeholder="Title"
+                            data-testid="post-title-field"
+                            required
+                          />
+                          <FormErrorMessage>
+                            {form.errors.title}
+                          </FormErrorMessage>
+                        </FormControl>
+                      )}
+                    </Field>
+                    <Button
+                      colorScheme="blue"
+                      isLoading={props.isSubmitting}
+                      type="submit"
+                      w="15%"
+                      margin={{ base: "0 0 1rem 0" }}
+                    >
+                      Done
+                    </Button>
+                  </Stack>
+                </Form>
+              )}
+            </Formik>
+          )}
+        </Flex>
+        <Box p="0 auto" m="0rem auto" w="100%" maxW="1060px">
+          <Tiptap
+            handleContentChange={handleContentChange}
+            content={content}
+            user={user}
+            postId={postId}
+          />
+        </Box>
       </Flex>
     </>
   );

--- a/apps/frontend/src/components/post-form.jsx
+++ b/apps/frontend/src/components/post-form.jsx
@@ -316,7 +316,7 @@ const PostForm = ({ tags, user, authors, post }) => {
                           >
                             <Input
                               {...field}
-                              placeholder="title"
+                              placeholder="Title"
                               data-testid="post-title-field"
                               required
                             />

--- a/apps/frontend/src/components/tiptap.jsx
+++ b/apps/frontend/src/components/tiptap.jsx
@@ -143,8 +143,8 @@ function ToolBar({ editor, user }) {
         <MenuButton
           as={Button}
           variant="ghost"
-          title="select heading text"
-          aria-label="select heading text"
+          title="Select heading text"
+          aria-label="Select heading text"
           iconSpacing={0}
           leftIcon={<FontAwesomeIcon icon={faHeader} />}
         />
@@ -154,7 +154,7 @@ function ToolBar({ editor, user }) {
               editor.chain().focus().toggleHeading({ level: 1 }).run()
             }
           >
-            Add heading 1
+            Heading 1
           </MenuItem>
 
           <MenuItem
@@ -162,7 +162,7 @@ function ToolBar({ editor, user }) {
               editor.chain().focus().toggleHeading({ level: 2 }).run()
             }
           >
-            Add heading 2
+            Heading 2
           </MenuItem>
 
           <MenuItem
@@ -170,7 +170,7 @@ function ToolBar({ editor, user }) {
               editor.chain().focus().toggleHeading({ level: 3 }).run()
             }
           >
-            Add heading 3
+            Heading 3
           </MenuItem>
 
           <MenuItem
@@ -178,21 +178,21 @@ function ToolBar({ editor, user }) {
               editor.chain().focus().toggleHeading({ level: 4 }).run()
             }
           >
-            Add heading 4
+            Heading 4
           </MenuItem>
           <MenuItem
             onClick={() =>
               editor.chain().focus().toggleHeading({ level: 5 }).run()
             }
           >
-            Add heading 5
+            Heading 5
           </MenuItem>
           <MenuItem
             onClick={() =>
               editor.chain().focus().toggleHeading({ level: 6 }).run()
             }
           >
-            Add heading 6
+            Heading 6
           </MenuItem>
         </MenuList>
       </Menu>

--- a/apps/frontend/src/components/tiptap.jsx
+++ b/apps/frontend/src/components/tiptap.jsx
@@ -1,6 +1,7 @@
 import {
   faBold,
   faCode,
+  faFileCode,
   faHeader,
   faImage,
   faItalic,
@@ -241,7 +242,7 @@ function ToolBar({ editor, user }) {
           iconSpacing={0}
           title="Select embed content"
           aria-label="Select embed content"
-          leftIcon={<FontAwesomeIcon icon={faCode} />}
+          leftIcon={<FontAwesomeIcon icon={faFileCode} />}
           variant="ghost"
         />
         <MenuList>

--- a/apps/frontend/src/pages/api/auth/[...nextauth].js
+++ b/apps/frontend/src/pages/api/auth/[...nextauth].js
@@ -108,7 +108,7 @@ export const authOptions = {
         if (res2.ok) {
           const userData = await res2.json();
           // Add the role name to session JWT
-          token.name = userData?.username || null;
+          token.name = userData?.name || null;
           token.userRole = userData?.role?.name || null;
           token.id = userData?.id || null;
           if (userData.profile_image !== null) {

--- a/apps/frontend/src/pages/posts/preview/[postId].js
+++ b/apps/frontend/src/pages/posts/preview/[postId].js
@@ -90,7 +90,7 @@ export default function PreviewArticlePage({ post }) {
 
   return (
     <>
-      <Box m="0rem auto" w="100vh" pt="5rem">
+      <Box m="0rem auto" w="100%" maxW="1060px" pt="5rem" px="4vw">
         <Text fontSize="xxx-large" fontWeight="bold">
           {post?.title}
         </Text>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Small fixes based on feedback from Estefania:

- Change the icon for embed content since the same icon was used for code block
- Simplify the text in the dropdown menu to add a heading
- Fix casing of the placeholder text in the title field
- Make the width of the editor similar to the width of published posts
- Show `name` field instead of Strapi's default `username` in the bottom left of the navigation menu

I also removed the outer `<Flex>` element in `post-form.jsx` that seemed unnecessary.

Screenshots:
![image](https://github.com/freeCodeCamp/publish/assets/25644062/71597421-4877-4978-8577-25632459edb6)
![image](https://github.com/freeCodeCamp/publish/assets/25644062/6749265e-ffe7-4764-ac0d-631268404539)
