### PR TITLE
fix: make feature image preview work in staging

### DIFF
--- a/apps/frontend/src/pages/posts/preview/[postId].js
+++ b/apps/frontend/src/pages/posts/preview/[postId].js
@@ -115,12 +115,13 @@ export default function PreviewArticlePage({ post, baseUrl }) {
         >
           {post.feature_image.data ? (
             <Image
-              src={baseUrl + post.feature_image.data.attributes.url}
+              src={new URL(post.feature_image.data.attributes.url, baseUrl)}
               alt="Post Image"
               w="100%"
               h="auto"
               maxH="500px"
               objectFit="cover"
+              data-testid="feature-image-preview"
             />
           ) : (
             <Box>

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "@playwright/test";
-import path from 'path';
 
 import { deletePost, getPostIdInURL, createPostWithFeatureImage } from "./helpers/post";
 

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -49,6 +49,6 @@ test.describe('feature image', () => {
     ]);
 
     // Check that the preview was opened successfully
-    expect(newPage.locator('text="No image provided"')).toBeVisible();
+    await expect(newPage.locator('text="No image provided"')).toBeVisible();
   });
 })

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -34,7 +34,7 @@ test.describe('feature image', () => {
     await expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
   });
 
-  test('preview should open without feature image', async ({ page, request }) => {
+  test('preview should open without feature image', async ({ page }) => {
     // Open a post
     await page.goto('/posts/1');
 

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import path from 'path';
+
+import { deletePost, getPostIdInURL, createPostWithFeatureImage } from "./helpers/post";
+
+test.describe('feature image', () => {
+  let postIdsToDelete: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    // delete all posts created in the tests
+    for (const postId of postIdsToDelete) {
+      await deletePost(request, postId);
+    }
+  })
+
+  test('feature image should be visible in preview', async ({ page, request }) => {
+    // Prepare existing post that has a feature image
+    const postId = await createPostWithFeatureImage(page, request);
+    if (postId) {
+      // Store the post id to delete after the test
+      postIdsToDelete.push(postId);
+    }
+
+    // Open a post
+    await page.goto(`/posts/${postId}`);
+
+    // Open the drawer
+    const drawerButton = page.getByTestId('open-post-drawer');
+    await drawerButton.click();
+
+    // Open the preview
+    const [newPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.getByRole('button', { name: 'Preview' }).click(),
+    ]);
+
+    // Wait for the new page to load
+    await newPage.waitForLoadState('load');
+
+    // Check that saved feature image is visible
+    expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
+  });
+
+  test('preview should open without feature image', async ({ page, request }) => {
+    // Open a post
+    await page.goto('/posts/1');
+
+    // Open the drawer
+    const drawerButton = page.getByTestId('open-post-drawer');
+    await drawerButton.click();
+
+    // Open the preview
+    const [newPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.getByRole('button', { name: 'Preview' }).click(),
+    ]);
+
+    // Wait for the new page to load
+    await newPage.waitForLoadState('load');
+
+    // Check that the preview was opened successfully
+    expect(newPage.locator('text="No image provided"')).toBeVisible();
+  });
+})

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -35,7 +35,7 @@ test.describe('feature image', () => {
     ]);
 
     // Wait for the new page to load
-    await newPage.waitForLoadState('load');
+    await newPage.locator('[data-testid="feature-image-preview"]').waitFor();
 
     // Check that saved feature image is visible
     expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
@@ -56,7 +56,7 @@ test.describe('feature image', () => {
     ]);
 
     // Wait for the new page to load
-    await newPage.waitForLoadState('load');
+    await newPage.locator('text="No image provided"').waitFor();
 
     // Check that the preview was opened successfully
     expect(newPage.locator('text="No image provided"')).toBeVisible();

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -32,7 +32,7 @@ test.describe('feature image', () => {
     ]);
 
     // Check that saved feature image is visible
-    expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
+    await expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
   });
 
   test('preview should open without feature image', async ({ page, request }) => {

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -49,9 +49,6 @@ test.describe('feature image', () => {
       page.getByRole('button', { name: 'Preview' }).click(),
     ]);
 
-    // Wait for the new page to load
-    await newPage.locator('text="No image provided"').waitFor();
-
     // Check that the preview was opened successfully
     expect(newPage.locator('text="No image provided"')).toBeVisible();
   });

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-import { deletePost, getPostIdInURL, createPostWithFeatureImage } from "./helpers/post";
+import { deletePost, createPostWithFeatureImage } from "./helpers/post";
 
 test.describe('feature image', () => {
   const postIdsToDelete: string[] = [];

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -16,10 +16,7 @@ test.describe('feature image', () => {
   test('feature image should be visible in preview', async ({ page, request }) => {
     // Prepare existing post that has a feature image
     const postId = await createPostWithFeatureImage(page, request);
-    if (postId) {
-      // Store the post id to delete after the test
-      postIdsToDelete.push(postId);
-    }
+    postIdsToDelete.push(postId);
 
     // Open a post
     await page.goto(`/posts/${postId}`);

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -31,9 +31,6 @@ test.describe('feature image', () => {
       page.getByRole('button', { name: 'Preview' }).click(),
     ]);
 
-    // Wait for the new page to load
-    await newPage.locator('[data-testid="feature-image-preview"]').waitFor();
-
     // Check that saved feature image is visible
     expect(newPage.getByTestId('feature-image-preview')).toBeVisible();
   });

--- a/e2e/posts-preview.spec.ts
+++ b/e2e/posts-preview.spec.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { deletePost, getPostIdInURL, createPostWithFeatureImage } from "./helpers/post";
 
 test.describe('feature image', () => {
-  let postIdsToDelete: string[] = [];
+  const postIdsToDelete: string[] = [];
 
   test.afterAll(async ({ request }) => {
     // delete all posts created in the tests


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

So I noticed the feature image in preview is broken when I deployed it to the staging server. It seems to be caused by the duplicate `/` in the URL.

I think this PR should fix it to work with or without trailing `/` in `NEXT_PUBLIC_STRAPI_BACKEND_URL` value.
