### PR TITLE
fix(test): update editor test to use keypresses

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -5,11 +5,15 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("it should be possible to type in the editor", async ({ page }) => {
-  const textToType = "Hello World";
-  await page.getByTestId("editor").fill(textToType);
+  const editor = page.getByTestId("editor");
+  const wordCount = page.getByTestId("word-count");
 
-  const wordCount = await page.getByTestId("word-count").innerText();
-  expect(wordCount).toBe(textToType.split(" ").length.toString() + " words");
+  await editor.press("Control+A");
+  await editor.press("Backspace");
+  await expect(wordCount).toHaveText("0 words");
+
+  await editor.pressSequentially("Hello World");
+  await expect(wordCount).toHaveText("2 words");
 });
 
 test("it should have eleven buttons in the toolbar", async ({ page }) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We're interested in checking how the editor responds to keypresses, so I think it's safer to apply keypresses directly (rather than treating it like an input element).

I also simplified the logic a bit: computing the number of words seemed redundant when we know it's two.

<!-- Feel free to add any additional description of changes below this line -->
