### PR TITLE
feat: sync editor configs

### DIFF
--- a/apps/frontend/src/components/tiptap.jsx
+++ b/apps/frontend/src/components/tiptap.jsx
@@ -36,18 +36,8 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Prose } from "@nikolovlazar/chakra-ui-prose";
-import CharacterCount from "@tiptap/extension-character-count";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import Image from "@tiptap/extension-image";
-import Link from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
-import Youtube from "@tiptap/extension-youtube";
 import { BubbleMenu, EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import { lowlight } from "lowlight";
 import { useEffect, useRef, useState } from "react";
-import { Markdown } from "tiptap-markdown";
-import { EditorContent, useEditor } from "@tiptap/react";
 
 import { extensions } from "@/lib/editor-config";
 

--- a/apps/frontend/src/components/tiptap.jsx
+++ b/apps/frontend/src/components/tiptap.jsx
@@ -47,6 +47,9 @@ import StarterKit from "@tiptap/starter-kit";
 import { lowlight } from "lowlight";
 import { useEffect, useRef, useState } from "react";
 import { Markdown } from "tiptap-markdown";
+import { EditorContent, useEditor } from "@tiptap/react";
+
+import { extensions } from "@/lib/editor-config";
 
 function ToolBar({ editor, user }) {
   const addYoutubeEmbed = () => {
@@ -463,45 +466,7 @@ const Tiptap = ({ handleContentChange, user, content }) => {
   const { getFloatingProps } = useInteractions([hover]);
 
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        bulletList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
-        orderedList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
-      }),
-      Placeholder.configure({
-        // Use a placeholder:
-        placeholder: "Write something …",
-      }),
-      Image.configure({
-        inline: true,
-        HTMLAttributes: {
-          class: "add-image-form",
-        },
-      }),
-      Youtube.configure({
-        width: 480,
-        height: 320,
-      }),
-      Link.configure({
-        protocols: ["http", "https", "mailto", "tel"],
-        autolink: false,
-        openOnClick: false,
-      }),
-      Markdown.configure({
-        transformPastedText: true,
-      }),
-      CodeBlockLowlight.configure({
-        defaultLanguage: "javascript",
-        lowlight,
-      }),
-      CharacterCount.configure({}),
-    ],
+    extensions,
     content: content ? content : "",
     autofocus: true,
     editorProps: {

--- a/apps/frontend/src/lib/editor-config.js
+++ b/apps/frontend/src/lib/editor-config.js
@@ -18,6 +18,7 @@ export const extensions = [
       keepMarks: true,
       keepAttributes: false,
     },
+    codeBlock: false,
   }),
   Placeholder.configure({
     // Use a placeholder:

--- a/apps/frontend/src/lib/editor-config.js
+++ b/apps/frontend/src/lib/editor-config.js
@@ -1,0 +1,48 @@
+import StarterKit from "@tiptap/starter-kit";
+import Youtube from "@tiptap/extension-youtube";
+import { Markdown } from "tiptap-markdown";
+import { lowlight } from "lowlight";
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import CharacterCount from "@tiptap/extension-character-count";
+import Image from "@tiptap/extension-image";
+import Placeholder from "@tiptap/extension-placeholder";
+import Link from "@tiptap/extension-link";
+
+export const extensions = [
+  StarterKit.configure({
+    bulletList: {
+      keepMarks: true,
+      keepAttributes: false,
+    },
+    orderedList: {
+      keepMarks: true,
+      keepAttributes: false,
+    },
+  }),
+  Placeholder.configure({
+    // Use a placeholder:
+    placeholder: "Write something …",
+  }),
+  Image.configure({
+    inline: true,
+    HTMLAttributes: {
+      class: "add-image-form",
+    },
+  }),
+  Youtube.configure({
+    width: 480,
+    height: 320,
+  }),
+  Link.configure({
+    protocols: ["http", "https", "mailto", "tel"],        autolink: false,
+    openOnClick: false,
+  }),
+  Markdown.configure({
+    transformPastedText: true,
+  }),
+  CodeBlockLowlight.configure({
+    defaultLanguage: "javascript",
+    lowlight,
+  }),
+  CharacterCount.configure({}),
+];

--- a/apps/frontend/src/lib/editor-config.js
+++ b/apps/frontend/src/lib/editor-config.js
@@ -35,7 +35,8 @@ export const extensions = [
     height: 320,
   }),
   Link.configure({
-    protocols: ["http", "https", "mailto", "tel"],        autolink: false,
+    protocols: ["http", "https", "mailto", "tel"],
+    autolink: false,
     openOnClick: false,
   }),
   Markdown.configure({

--- a/apps/frontend/src/pages/posts/preview/[postId].js
+++ b/apps/frontend/src/pages/posts/preview/[postId].js
@@ -4,15 +4,9 @@ import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { getPost } from "@/lib/posts";
 import { Prose } from "@nikolovlazar/chakra-ui-prose";
 import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import Placeholder from "@tiptap/extension-placeholder";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-
-import { Image as TiptapImage } from "@tiptap/extension-image";
-import Youtube from "@tiptap/extension-youtube";
-import Link from "@tiptap/extension-link";
 import { Text, Box, Image, useToast } from "@chakra-ui/react";
-import { lowlight } from "lowlight";
+
+import { extensions } from "@/lib/editor-config";
 
 export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -43,36 +37,7 @@ export default function PreviewArticlePage({ post, baseUrl }) {
   const toastIdRef = useRef();
 
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        bulletList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
-        orderedList: {
-          keepMarks: true,
-          keepAttributes: false,
-        },
-      }),
-      Placeholder.configure({
-        // Use a placeholder:
-        placeholder: "Write something …",
-      }),
-      TiptapImage.configure({
-        inline: true,
-      }),
-      Youtube.configure({
-        width: 480,
-        height: 320,
-      }),
-      CodeBlockLowlight.configure({
-        defaultLanguage: "javascript",
-        lowlight,
-      }),
-      Link.configure({
-        protocols: ["http", "https", "mailto", "tel"],
-      }),
-    ],
+    extensions,
     content: post?.body,
     editable: false,
     editorProps: {


### PR DESCRIPTION
- feat: sync tiptap extensions between editors
- fix: only add CodeBlock extension once

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There doesn't seem to be an obvious reason why the preview and the working editor should display differently (as much as possible we want the working editor to be WYSIWYG).

This does change the preview.

Before:

![image](https://github.com/freeCodeCamp/publish/assets/15801806/54dd0d4b-6785-4f11-8444-e3c0ca7851bf)

After:

![image](https://github.com/freeCodeCamp/publish/assets/15801806/62130527-122c-4719-9180-2adea3a713ab)



<!-- Feel free to add any additional description of changes below this line -->
